### PR TITLE
Modify addtile API to allow for mass importing

### DIFF
--- a/Tilesheets.php
+++ b/Tilesheets.php
@@ -26,8 +26,8 @@
     $wgAPIListModules['tiles'] = 'TilesheetsQueryTilesApi';
     $wgAutoloadClasses['TilesheetsQueryTranslationsApi'] = __DIR__ . '/api/TilesheetsQueryTranslationsApi.php';
     $wgAPIListModules['tiletranslations'] = 'TilesheetsQueryTranslationsApi';
-    $wgAutoloadClasses['TilesheetsAddTileApi'] = __DIR__ . '/api/TilesheetsAddTileApi.php';
-    $wgAPIModules['addtile'] = 'TilesheetsAddTileApi';
+    $wgAutoloadClasses['TilesheetsAddTilesApi'] = __DIR__ . '/api/TilesheetsAddTilesApi.php';
+    $wgAPIModules['addtiles'] = 'TilesheetsAddTilesApi';
     $wgAutoloadClasses['TilesheetsDeleteSheetApi'] = __DIR__ . '/api/TilesheetsDeleteSheetApi.php';
     $wgAPIModules['deletesheet'] = 'TilesheetsDeleteSheetApi';
     $wgAutoloadClasses['TilesheetsAddSheetApi'] = __DIR__ . '/api/TilesheetsAddSheetApi.php';

--- a/extension.json
+++ b/extension.json
@@ -54,7 +54,7 @@
 		"TilesheetsQuerySheetsApi": "api/TilesheetsQuerySheetsApi.php",
 		"TilesheetsQueryTilesApi": "api/TilesheetsQueryTilesApi.php",
 		"TilesheetsQueryTranslationsApi": "api/TilesheetsQueryTranslationsApi.php",
-		"TilesheetsAddTileApi": "api/TilesheetsAddTileApi.php",
+		"TilesheetsAddTilesApi": "api/TilesheetsAddTilesApi.php",
 		"TilesheetsDeleteSheetApi": "api/TilesheetsDeleteSheetApi.php",
 		"TilesheetsAddSheetApi": "api/TilesheetsAddSheetApi.php",
 		"TilesheetsDeleteTilesApi": "api/TilesheetsDeleteTilesApi.php",
@@ -64,7 +64,7 @@
 		"TilesheetsTranslateTileApi": "api/TilesheetsTranslateTileApi.php"
 	},
 	"APIModules": {
-		"addtile": "TilesheetsAddTileApi",
+		"addtiles": "TilesheetsAddTilesApi",
 		"deletesheet": "TilesheetsDeleteSheetApi",
 		"createsheet": "TilesheetsAddSheetApi",
 		"deletetiles": "TilesheetsDeleteTilesApi",


### PR DESCRIPTION
This changes the `addtile` API (breaking change; major version bump after merge) to `addtiles`. It allows you to specify the tiles to add in the following format `X Y Name|X Y Name|X Y Name`. The `name`, `x`, and `y` parameters have been removed and replaced by the `import` parameter. The return value is in `addtiles` rather than `addtile` as well.