### PR TITLE
Missing special page alias file.

### DIFF
--- a/Tilesheets.alias.php
+++ b/Tilesheets.alias.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Tilesheets
+ * Tilesheets Aliases
+ *
+ * @license		MIT
+ * @package		Tilesheets
+ * @link		https://github.com/FTB-Gamepedia/Tilesheets
+**/
+
+$specialPageAliases = [];
+
+/** English (English) */
+$specialPageAliases['en'] = [
+	'CreateTileSheet' => ['CreateTileSheet'],
+	'SheetList' => ['SheetList'],
+	'SheetManager' => ['SheetManager'],
+	'TileList' => ['TileList'],
+	'TileManager' => ['TileManager'],
+	'TileTranslator' => ['TileTranslator']
+];

--- a/extension.json
+++ b/extension.json
@@ -38,6 +38,7 @@
 		]
 	},
 	"ExtensionMessagesFiles": {
+		"SpecialTilesheets": "Tilesheets.alias.php",
 		"TilesheetsMagic": "Tilesheets.i18n.magic.php"
 	},
 	"AutoloadClasses": {


### PR DESCRIPTION
This resolves debug error messages shown in the MediaWiki console.  The alias file also allows the title of the special page, in the URL, to be localized.