### PR TITLE
Use addIndex for add_primary_key schema update

### DIFF
--- a/Tilesheets.hooks.php
+++ b/Tilesheets.hooks.php
@@ -27,7 +27,7 @@ class TilesheetsHooks {
 		$updater->addExtensionUpdate(['addTable', 'ext_tilesheet_tilelinks', "{$extDir}/install/sql/ext_tilesheet_tilelinks.sql", true]);
 
 		$updater->addExtensionUpdate(['modifyField', 'ext_tilesheet_languages', 'description', "{$extDir}/upgrade/sql/ext_tilesheet_languages/change_description_to_text.sql", true]);
-		$updater->addExtensionUpdate(['modifyField', 'ext_tilesheet_languages', 'entry_id', "{$extDir}/upgrade/sql/ext_tilesheet_languages/add_primary_key.sql", true]);
+		$updater->addExtensionUpdate(['addIndex', 'ext_tilesheet_languages', 'PRIMARY', "{$extDir}/upgrade/sql/ext_tilesheet_languages/add_primary_key.sql", true]);
 		return true;
 	}
 


### PR DESCRIPTION
Running update.php on a fresh install currently fails trying to add a second primary key to the table.