### PR TITLE
TilesheetsHooks::addCacheToTileLinks attempts to process non-array on DB update.

### DIFF
--- a/Tilesheets.hooks.php
+++ b/Tilesheets.hooks.php
@@ -223,6 +223,9 @@ class TilesheetsHooks {
 		$pageName = $title->getText();
 		$page = $title->getArticleID();
 		self::clearTileLinksForPage($page, $namespace);
+		if (!isset(Tilesheets::$tileLinks[$namespace][$pageName])) {
+			return true;
+		}
 		array_unique(Tilesheets::$tileLinks[$namespace][$pageName]);
 		foreach (Tilesheets::$tileLinks[$namespace][$pageName] as $entryID) {
 			self::addToTileLinks($page, $namespace, $entryID);

--- a/extension.json
+++ b/extension.json
@@ -18,6 +18,13 @@
 		"importtilesheets",
 		"translatetiles"
 	],
+	"GrantPermissions": {
+		"tilesheets": {
+			"edittilesheets": true,
+			"importtilesheets": true,
+			"translatetiles": true
+		}
+	},
 	"SpecialPages": {
 		"TileList": "TileList",
 		"SheetList": "SheetList",
@@ -138,14 +145,7 @@
 			"tilesheet-missing-item-category",
 			"tilesheet-no-mod-provided-category",
 			"tilesheet-no-mod-provided-easy-category"
-		],
-		"GrantPermissions": {
-			"tilesheets": {
-				"edittilesheets": true,
-				"importtilesheets": true,
-				"translatetiles": true
-			}
-		}
+		]
 	},
 	"manifest_version": 1
 }


### PR DESCRIPTION
If an extension edits a page on database update and that page was previously deleted Tilesheets will attempt to process over a non-array.  Hopefully this is the correct way to fix this.

PHP Warning:  array_unique() expects parameter 1 to be array, null given in extensions/Tilesheets/Tilesheets.hooks.php on line 226
PHP Warning:  Invalid argument supplied for foreach() in extensions/Tilesheets/Tilesheets.hooks.php on line 227