### PR TITLE
Upgrade for MediaWiki 1.39

### DIFF
--- a/Tilesheets.body.php
+++ b/Tilesheets.body.php
@@ -1,7 +1,6 @@
 <?php
 use Wikimedia\Rdbms\ILoadBalancer;
 use MediaWiki\MediaWikiServices;
-use MediaWiki\Page\PageLookup;
 
 /**
  * Tilesheets main body file

--- a/Tilesheets.body.php
+++ b/Tilesheets.body.php
@@ -1,5 +1,6 @@
 <?php
 use Wikimedia\Rdbms\ILoadBalancer;
+use MediaWiki\MediaWikiServices;
 
 /**
  * Tilesheets main body file
@@ -36,7 +37,7 @@ class Tilesheets {
 
 		TilesheetsError::log(wfMessage('tilesheets-log-prepare')->params($size, $item, $mod)->text());
 
-		$dbr = wfGetDB(DB_SLAVE);
+		$dbr = MediaWikiServices::getInstance()->getDBLoadBalancer()->getConnection(DB_REPLICA);
 
 		if (!isset(self::$mQueriedItems[$item])) {
 			$results = $dbr->select('ext_tilesheet_items','*',array('item_name' => $item));
@@ -156,7 +157,7 @@ class Tilesheets {
 	 * @return mixed
 	 */
 	public static function getModTileSizes($mod) {
-		$dbr = wfGetDB(DB_SLAVE);
+		$dbr = MediaWikiServices::getInstance()->getDBLoadBalancer()->getConnection(DB_REPLICA);
 		if (!isset(self::$mQueriedSizes[$mod])) {
 			$result = $dbr->select('ext_tilesheet_images','sizes',array("`mod`" => $mod));
 			TilesheetsError::query($dbr->lastQuery());

--- a/Tilesheets.body.php
+++ b/Tilesheets.body.php
@@ -138,7 +138,7 @@ class Tilesheets {
 		$page = $title->getText();
 		$namespace = $title->getNamespace();
 		self::$tileLinks[$namespace][$page][] = $entryID;
-		$file = wfFindFile("Tilesheet $mod $size $z.png");
+		$file = MediaWikiServices::getInstance()->getRepoGroup()->findFile("Tilesheet $mod $size $z.png");
 		if ($file === false) {
 			$parser->addTrackingCategory('tilesheet-missing-image-category');
 			TilesheetsError::warn(wfMessage('tilesheets-warning-noimage')->params($mod, $size, $z)->text());

--- a/Tilesheets.body.php
+++ b/Tilesheets.body.php
@@ -1,4 +1,6 @@
 <?php
+use Wikimedia\Rdbms\ILoadBalancer;
+
 /**
  * Tilesheets main body file
  *
@@ -192,12 +194,13 @@ class Tilesheets {
 	 * @param string $toMod 	The new mod abbreviation.
 	 * @param string $toSizes 	The new sizes, separated by commas.
 	 * @param User $user 		The user performing the change.
+	 * @param ILoadBalancer $dbLoadBalancer 	The DBLoadBalancer service.
 	 * @param string $comment	The edit summary.
 	 * @return bool				Whether or not the edit was successful.
 	 * @throws MWException		See Database#query.
 	 */
-	public static function updateSheetRow($curMod, $toMod, $toSizes, $user, $comment = '') {
-		$dbw = wfGetDB(DB_MASTER);
+	public static function updateSheetRow($curMod, $toMod, $toSizes, $user, ILoadBalancer $dbLoadBalancer, $comment = '') {
+		$dbw = $dbLoadBalancer->getConnection(DB_PRIMARY);
 		$stuff = $dbw->select('ext_tilesheet_images', '*', array('`mod`' => $curMod));
 		$result = $dbw->update('ext_tilesheet_images', array('sizes' => $toSizes, '`mod`' => $toMod), array('`mod`' => $curMod));
 

--- a/Tilesheets.hooks.php
+++ b/Tilesheets.hooks.php
@@ -90,7 +90,7 @@ class TilesheetsHooks {
 	 * @return string The localized content, or the provided item's name as fall back.
 	 */
 	public static function IconLocalization(Parser &$parser, $item, $mod, $type = 'name', $language = 'en') {
-		$dbr = wfGetDB(DB_SLAVE);
+		$dbr = wfGetDB(DB_REPLICA);
 		$items = $dbr->select('ext_tilesheet_items', 'entry_id', array('item_name' => $item, 'mod_name' => $mod));
 
 		if ($items->numRows() == 0) {
@@ -200,7 +200,7 @@ class TilesheetsHooks {
 	public static function onArticleMove(Title &$oldTitle, Title &$newTitle) {
 		// It's worth noting that the ID doesn't change when pages are moved, according to Manual:Page table
 		// However, you can move pages across namespaces, so we still need to update the table.
-		$dbw = wfGetDB(DB_MASTER);
+		$dbw = wfGetDB(DB_PRIMARY);
 		$dbw->update('ext_tilesheet_tilelinks',
 			array(
 				'tl_from_namespace' => $newTitle->getNamespace()
@@ -237,7 +237,7 @@ class TilesheetsHooks {
 	}
 
 	public static function clearTileLinksForPage($pageID, $namespaceID) {
-		$dbw = wfGetDB(DB_MASTER);
+		$dbw = wfGetDB(DB_PRIMARY);
 		$dbw->delete('ext_tilesheet_tilelinks', array(
 			'`tl_from`' => $pageID,
 			'`tl_from_namespace`' => $namespaceID
@@ -245,7 +245,7 @@ class TilesheetsHooks {
 	}
 
 	public static function addToTileLinks($pageID, $namespaceID, $tileID) {
-		$dbw = wfgetDB(DB_MASTER);
+		$dbw = wfGetDB(DB_PRIMARY);
 
 		$result = $dbw->select('ext_tilesheet_tilelinks', 'COUNT(`tl_to`) AS count', array(
 			'`tl_from`' => $pageID,

--- a/Tilesheets.hooks.php
+++ b/Tilesheets.hooks.php
@@ -1,4 +1,5 @@
 <?php
+use MediaWiki\MediaWikiServices;
 use MediaWiki\Hook\BeforePageDisplayHook;
 use MediaWiki\Hook\EditPage__showEditForm_initialHook;
 use MediaWiki\Hook\ParserFirstCallInitHook;
@@ -94,7 +95,7 @@ class TilesheetsHooks implements LoadExtensionSchemaUpdatesHook, ParserFirstCall
 	 * @return string The localized content, or the provided item's name as fall back.
 	 */
 	public static function IconLocalization(Parser $parser, $item, $mod, $type = 'name', $language = 'en') {
-		$dbr = wfGetDB(DB_REPLICA);
+		$dbr = MediaWikiServices::getInstance()->getDBLoadBalancer()->getConnection(DB_REPLICA);
 		$items = $dbr->select('ext_tilesheet_items', 'entry_id', array('item_name' => $item, 'mod_name' => $mod));
 
 		if ($items->numRows() == 0) {

--- a/api/TilesheetsAddSheetApi.php
+++ b/api/TilesheetsAddSheetApi.php
@@ -51,7 +51,7 @@ class TilesheetsAddSheetApi extends ApiBase {
     }
 
     public function execute() {
-    	if (!$this->permissionmManager->userHasRight($this->getUser(), 'edittilesheets')) {
+        if (!$this->permissionmManager->userHasRight($this->getUser(), 'edittilesheets')) {
             $this->dieWithError('You do not have permission to create tilesheets', 'permissiondenied');
         }
 

--- a/api/TilesheetsAddSheetApi.php
+++ b/api/TilesheetsAddSheetApi.php
@@ -12,7 +12,10 @@ class TilesheetsAddSheetApi extends ApiBase {
     public function getAllowedParams() {
         return array(
             'token' => null,
-            'summary' => null,
+            'summary' => array(
+            	ParamValidator::PARAM_TYPE => 'string',
+            	ParamValidator::PARAM_DEFAULT => ''
+            ),
             'mod' => array(
                 ParamValidator::PARAM_TYPE => 'string',
                 ParamValidator::PARAM_REQUIRED => true,

--- a/api/TilesheetsAddSheetApi.php
+++ b/api/TilesheetsAddSheetApi.php
@@ -19,7 +19,7 @@ class TilesheetsAddSheetApi extends ApiBase {
             ),
             'sizes' => array(
                 ParamValidator::PARAM_TYPE => 'string',
-                ParamValidator::PARAM_DFLT => '16|32',
+                ParamValidator::PARAM_DEFAULT => '16|32',
                 ParamValidator::PARAM_ISMULTI => true,
             ),
         );

--- a/api/TilesheetsAddTilesApi.php
+++ b/api/TilesheetsAddTilesApi.php
@@ -52,7 +52,7 @@ class TilesheetsAddTilesApi extends ApiBase {
     }
 
     public function execute() {
-    	if (!$this->permissionManager->userHasRight($this->getUser(), 'edittilesheets')) {
+        if (!$this->permissionManager->userHasRight($this->getUser(), 'edittilesheets')) {
             $this->dieWithError('You do not have permission to add tiles', 'permissiondenied');
         }
 

--- a/api/TilesheetsAddTilesApi.php
+++ b/api/TilesheetsAddTilesApi.php
@@ -1,7 +1,11 @@
 <?php
 
+use Wikimedia\ParamValidator\ParamValidator;
+use Wikimedia\Rdbms\ILoadBalancer;
+use MediaWiki\Permissions\PermissionManager;
+
 class TilesheetsAddTilesApi extends ApiBase {
-    public function __construct($query, $moduleName) {
+    public function __construct($query, $moduleName, private ILoadBalancer $dbLoadBalancer, private PermissionManager $permissionManager) {
         parent::__construct($query, $moduleName, 'ts');
     }
 
@@ -10,14 +14,14 @@ class TilesheetsAddTilesApi extends ApiBase {
             'token' => null,
             'summary' => null,
             'mod' => array(
-                ApiBase::PARAM_TYPE => 'string',
-                ApiBase::PARAM_REQUIRED => true,
+                ParamValidator::PARAM_TYPE => 'string',
+                ParamValidator::PARAM_REQUIRED => true,
             ),
             'import' => array(
-                ApiBase::PARAM_TYPE => 'string',
-                ApiBase::PARAM_REQUIRED => true,
-                ApiBase::PARAM_ISMULTI => true,
-                ApiBase::PARAM_ALLOW_DUPLICATES => false,
+                ParamValidator::PARAM_TYPE => 'string',
+                ParamValidator::PARAM_REQUIRED => true,
+                ParamValidator::PARAM_ISMULTI => true,
+                ParamValidator::PARAM_ALLOW_DUPLICATES => false,
             ),
         );
     }
@@ -45,7 +49,7 @@ class TilesheetsAddTilesApi extends ApiBase {
     }
 
     public function execute() {
-        if (!in_array('edittilesheets', $this->getUser()->getRights())) {
+    	if (!$this->permissionManager->userHasRight($this->getUser(), 'edittilesheets')) {
             $this->dieWithError('You do not have permission to add tiles', 'permissiondenied');
         }
 
@@ -53,7 +57,7 @@ class TilesheetsAddTilesApi extends ApiBase {
         $summary = $this->getParameter('summary');
         $import = $this->getParameter('import');
 
-        $dbr = wfGetDB(DB_SLAVE);
+        $dbr = $this->dbLoadBalancer->getConnection(DB_REPLICA);
         $result = $dbr->select(
             'ext_tilesheet_images',
             '`mod`',
@@ -68,7 +72,7 @@ class TilesheetsAddTilesApi extends ApiBase {
         $return = [];
         foreach ($import as $entry) {
             list($x, $y, $z, $item) = explode(' ', $entry, 4);
-            $res = TileManager::createTile($mod, $item, $x, $y, $z, $this->getUser(), $summary);
+            $res = TileManager::createTile($mod, $item, $x, $y, $z, $this->getUser(), $this->dbLoadBalancer, $summary);
             // Get the new tile's ID.
             if ($res) {
                 $selectResult = $dbr->select(

--- a/api/TilesheetsAddTilesApi.php
+++ b/api/TilesheetsAddTilesApi.php
@@ -12,7 +12,10 @@ class TilesheetsAddTilesApi extends ApiBase {
     public function getAllowedParams() {
         return array(
             'token' => null,
-            'summary' => null,
+            'summary' => array(
+            	ParamValidator::PARAM_TYPE => 'string',
+            	ParamValidator::PARAM_DEFAULT => ''
+            ),
             'mod' => array(
                 ParamValidator::PARAM_TYPE => 'string',
                 ParamValidator::PARAM_REQUIRED => true,

--- a/api/TilesheetsDeleteSheetApi.php
+++ b/api/TilesheetsDeleteSheetApi.php
@@ -17,7 +17,10 @@ class TilesheetsDeleteSheetApi extends ApiBase {
                 ParamValidator::PARAM_ALLOW_DUPLICATES => false,
                 ParamValidator::PARAM_ISMULTI => true,
             ),
-            'summary' => null,
+            'summary' => array(
+            	ParamValidator::PARAM_TYPE => 'string',
+            	ParamValidator::PARAM_DEFAULT => ''
+            ),
             'token' => null,
         );
     }

--- a/api/TilesheetsDeleteSheetApi.php
+++ b/api/TilesheetsDeleteSheetApi.php
@@ -5,7 +5,7 @@ use MediaWiki\Permissions\PermissionManager;
 use Wikimedia\ParamValidator\ParamValidator;
 
 class TilesheetsDeleteSheetApi extends ApiBase {
-	public function __construct($query, $moduleName, private ILoadBalancer $dbLoadBalancer, private PermissionManager $permissionManager) {
+    public function __construct($query, $moduleName, private ILoadBalancer $dbLoadBalancer, private PermissionManager $permissionManager) {
         parent::__construct($query, $moduleName, 'ts');
     }
 
@@ -48,7 +48,7 @@ class TilesheetsDeleteSheetApi extends ApiBase {
     }
 
     public function execute() {
-    	if (!$this->permissionManager->userHasRight($this->getUser(), 'edittilesheets')) {
+        if (!$this->permissionManager->userHasRight($this->getUser(), 'edittilesheets')) {
             $this->dieWithError('You do not have permission to edit tilesheets', 'permissiondenied');
         }
 
@@ -57,7 +57,7 @@ class TilesheetsDeleteSheetApi extends ApiBase {
         $ret = array();
 
         foreach ($mods as $mod) {
-        	$ret[$mod] = SheetManager::deleteEntry($mod, $this->getUser(), $this->dbLoadBalancer, $summary);
+            $ret[$mod] = SheetManager::deleteEntry($mod, $this->getUser(), $this->dbLoadBalancer, $summary);
         }
 
         $this->getResult()->addValue('edit', 'deletesheet', $ret);

--- a/api/TilesheetsDeleteTilesApi.php
+++ b/api/TilesheetsDeleteTilesApi.php
@@ -6,7 +6,7 @@ use Wikimedia\ParamValidator\ParamValidator;
 use Wikimedia\ParamValidator\TypeDef\IntegerDef;
 
 class TilesheetsDeleteTilesApi extends ApiBase {
-	public function __construct($query, $moduleName, private ILoadBalancer $dbLoadBalancer, private PermissionManager $permissionManager) {
+    public function __construct($query, $moduleName, private ILoadBalancer $dbLoadBalancer, private PermissionManager $permissionManager) {
         parent::__construct($query, $moduleName, 'ts');
     }
 
@@ -49,7 +49,7 @@ class TilesheetsDeleteTilesApi extends ApiBase {
     }
 
     public function execute() {
-    	if (!$this->permissionManager->userHasRight($this->getUser(), 'edittilesheets')) {
+        if (!$this->permissionManager->userHasRight($this->getUser(), 'edittilesheets')) {
             $this->dieWithError('You do not have permission to delete tiles', 'permissiondenied');
         }
 
@@ -58,7 +58,7 @@ class TilesheetsDeleteTilesApi extends ApiBase {
 
         $ret = array();
         foreach ($ids as $id) {
-        	$result = TileManager::deleteEntry($id, $this->getUser(), $this->dbLoadBalancer, $summary);
+            $result = TileManager::deleteEntry($id, $this->getUser(), $this->dbLoadBalancer, $summary);
             $ret[$id] = $result;
         }
 

--- a/api/TilesheetsDeleteTilesApi.php
+++ b/api/TilesheetsDeleteTilesApi.php
@@ -13,7 +13,10 @@ class TilesheetsDeleteTilesApi extends ApiBase {
     public function getAllowedParams() {
         return array(
             'token' => null,
-            'summary' => null,
+            'summary' => array(
+            	ParamValidator::PARAM_TYPE => 'string',
+            	ParamValidator::PARAM_DEFAULT => ''
+            ),
             'ids' => array(
                 ParamValidator::PARAM_TYPE => 'integer',
                 ParamValidator::PARAM_REQUIRED => true,

--- a/api/TilesheetsDeleteTilesApi.php
+++ b/api/TilesheetsDeleteTilesApi.php
@@ -3,6 +3,7 @@
 use Wikimedia\Rdbms\ILoadBalancer;
 use MediaWiki\Permissions\PermissionManager;
 use Wikimedia\ParamValidator\ParamValidator;
+use Wikimedia\ParamValidator\TypeDef\IntegerDef;
 
 class TilesheetsDeleteTilesApi extends ApiBase {
 	public function __construct($query, $moduleName, private ILoadBalancer $dbLoadBalancer, private PermissionManager $permissionManager) {
@@ -17,7 +18,7 @@ class TilesheetsDeleteTilesApi extends ApiBase {
                 ParamValidator::PARAM_TYPE => 'integer',
                 ParamValidator::PARAM_REQUIRED => true,
                 ParamValidator::PARAM_ISMULTI => true,
-                ParamValidator::PARAM_MIN => 1,
+                IntegerDef::PARAM_MIN => 1,
             ),
         );
     }

--- a/api/TilesheetsDeleteTranslationApi.php
+++ b/api/TilesheetsDeleteTranslationApi.php
@@ -6,7 +6,7 @@ use Wikimedia\ParamValidator\ParamValidator;
 use Wikimedia\ParamValidator\TypeDef\IntegerDef;
 
 class TilesheetsDeleteTranslationApi extends ApiBase {
-	public function __construct($query, $moduleName, private ILoadBalancer $dbLoadBalancer, private PermissionManager $permissionManager) {
+    public function __construct($query, $moduleName, private ILoadBalancer $dbLoadBalancer, private PermissionManager $permissionManager) {
         parent::__construct($query, $moduleName, 'ts');
     }
 
@@ -48,7 +48,7 @@ class TilesheetsDeleteTranslationApi extends ApiBase {
     }
 
     public function execute() {
-    	if (!$this->permissionManager->userHasRight($this->getUser(), 'edittilesheets')) {
+        if (!$this->permissionManager->userHasRight($this->getUser(), 'edittilesheets')) {
             $this->dieWithError('You do not have permission to delete tile translations', 'permissiondenied');
         }
 

--- a/api/TilesheetsDeleteTranslationApi.php
+++ b/api/TilesheetsDeleteTranslationApi.php
@@ -3,6 +3,7 @@
 use Wikimedia\Rdbms\ILoadBalancer;
 use MediaWiki\Permissions\PermissionManager;
 use Wikimedia\ParamValidator\ParamValidator;
+use Wikimedia\ParamValidator\TypeDef\IntegerDef;
 
 class TilesheetsDeleteTranslationApi extends ApiBase {
 	public function __construct($query, $moduleName, private ILoadBalancer $dbLoadBalancer, private PermissionManager $permissionManager) {
@@ -15,7 +16,7 @@ class TilesheetsDeleteTranslationApi extends ApiBase {
             'id' => array(
                 ParamValidator::PARAM_TYPE => 'integer',
                 ParamValidator::PARAM_REQUIRED => true,
-                ParamValidator::PARAM_MIN => 1,
+                IntegerDef::PARAM_MIN => 1,
             ),
             'lang' => array(
                 ParamValidator::PARAM_TYPE => 'string',

--- a/api/TilesheetsDeleteTranslationApi.php
+++ b/api/TilesheetsDeleteTranslationApi.php
@@ -1,7 +1,11 @@
 <?php
 
+use Wikimedia\Rdbms\ILoadBalancer;
+use MediaWiki\Permissions\PermissionManager;
+use Wikimedia\ParamValidator\ParamValidator;
+
 class TilesheetsDeleteTranslationApi extends ApiBase {
-    public function __construct($query, $moduleName) {
+	public function __construct($query, $moduleName, private ILoadBalancer $dbLoadBalancer, private PermissionManager $permissionManager) {
         parent::__construct($query, $moduleName, 'ts');
     }
 
@@ -9,13 +13,13 @@ class TilesheetsDeleteTranslationApi extends ApiBase {
         return array(
             'token' => null,
             'id' => array(
-                ApiBase::PARAM_TYPE => 'integer',
-                ApiBase::PARAM_REQUIRED => true,
-                ApiBase::PARAM_MIN => 1,
+                ParamValidator::PARAM_TYPE => 'integer',
+                ParamValidator::PARAM_REQUIRED => true,
+                ParamValidator::PARAM_MIN => 1,
             ),
             'lang' => array(
-                ApiBase::PARAM_TYPE => 'string',
-                ApiBase::PARAM_REQUIRED => true,
+                ParamValidator::PARAM_TYPE => 'string',
+                ParamValidator::PARAM_REQUIRED => true,
             ),
         );
     }
@@ -43,14 +47,14 @@ class TilesheetsDeleteTranslationApi extends ApiBase {
     }
 
     public function execute() {
-        if (!in_array('edittilesheets', $this->getUser()->getRights())) {
+    	if (!$this->permissionManager->userHasRight($this->getUser(), 'edittilesheets')) {
             $this->dieWithError('You do not have permission to delete tile translations', 'permissiondenied');
         }
 
         $id = $this->getParameter('id');
         $lang = $this->getParameter('lang');
 
-        $response = TileTranslator::deleteEntry($id, $lang, $this->getUser());
+        $response = TileTranslator::deleteEntry($id, $lang, $this->getUser(), $this->dbLoadBalancer);
         if ($response == true) {
             $this->getResult()->addValue('edit', 'deletetranslation', array('id' => $id, 'language' => $lang));
         } else {

--- a/api/TilesheetsEditSheetApi.php
+++ b/api/TilesheetsEditSheetApi.php
@@ -1,7 +1,11 @@
 <?php
 
+use Wikimedia\Rdbms\ILoadBalancer;
+use MediaWiki\Permissions\PermissionManager;
+use Wikimedia\ParamValidator\ParamValidator;
+
 class TilesheetsEditSheetApi extends ApiBase {
-    public function __construct($query, $moduleName) {
+	public function __construct($query, $moduleName, private ILoadBalancer $dbLoadBalancer, private PermissionManager $permissionManager) {
         parent::__construct($query, $moduleName, 'ts');
     }
 
@@ -10,15 +14,15 @@ class TilesheetsEditSheetApi extends ApiBase {
             'token' => null,
             'summary' => null,
             'mod' => array(
-                ApiBase::PARAM_TYPE => 'string',
-                ApiBase::PARAM_REQUIRED => true,
+                ParamValidator::PARAM_TYPE => 'string',
+                ParamValidator::PARAM_REQUIRED => true,
             ),
             'tomod' => array(
-                ApiBase::PARAM_TYPE => 'string',
+                ParamValidator::PARAM_TYPE => 'string',
             ),
             'tosizes' => array(
-                ApiBase::PARAM_TYPE => 'integer',
-                ApiBase::PARAM_ISMULTI => true,
+                ParamValidator::PARAM_TYPE => 'integer',
+                ParamValidator::PARAM_ISMULTI => true,
             ),
         );
     }
@@ -46,7 +50,7 @@ class TilesheetsEditSheetApi extends ApiBase {
     }
 
     public function execute() {
-        if (!in_array('edittilesheets', $this->getUser()->getRights())) {
+    	if (!$this->permissionManager->userHasRight($this->getUser(), 'edittilesheets')) {
             $this->dieWithError('You do not have permission to edit sheets', 'permissiondenied');
         }
 
@@ -59,7 +63,7 @@ class TilesheetsEditSheetApi extends ApiBase {
             $this->dieWithError('You have to specify one of tomod or tosizes', 'nochangeparams');
         }
 
-        $dbr = wfGetDB(DB_SLAVE);
+        $dbr = $this->dbLoadBalancer->getConnection(DB_REPLICA);
         $entry = $dbr->select('ext_tilesheet_images', '*', array('`mod`' => $curMod));
 
         if ($entry->numRows() == 0) {
@@ -75,7 +79,7 @@ class TilesheetsEditSheetApi extends ApiBase {
             $this->dieWithError('There was no change', 'nochange');
         }
 
-        $result = Tilesheets::updateSheetRow($curMod, $toMod, $toSizes, $this->getUser(), $summary);
+        $result = Tilesheets::updateSheetRow($curMod, $toMod, $toSizes, $this->getUser(), $this->dbLoadBalancer, $summary);
         if ($result) {
             $this->getResult()->addValue('edit', 'editsheet', array($curMod => $toMod, $row->sizes => $toSizes));
         } else {

--- a/api/TilesheetsEditSheetApi.php
+++ b/api/TilesheetsEditSheetApi.php
@@ -5,7 +5,7 @@ use MediaWiki\Permissions\PermissionManager;
 use Wikimedia\ParamValidator\ParamValidator;
 
 class TilesheetsEditSheetApi extends ApiBase {
-	public function __construct($query, $moduleName, private ILoadBalancer $dbLoadBalancer, private PermissionManager $permissionManager) {
+    public function __construct($query, $moduleName, private ILoadBalancer $dbLoadBalancer, private PermissionManager $permissionManager) {
         parent::__construct($query, $moduleName, 'ts');
     }
 
@@ -53,7 +53,7 @@ class TilesheetsEditSheetApi extends ApiBase {
     }
 
     public function execute() {
-    	if (!$this->permissionManager->userHasRight($this->getUser(), 'edittilesheets')) {
+        if (!$this->permissionManager->userHasRight($this->getUser(), 'edittilesheets')) {
             $this->dieWithError('You do not have permission to edit sheets', 'permissiondenied');
         }
 

--- a/api/TilesheetsEditSheetApi.php
+++ b/api/TilesheetsEditSheetApi.php
@@ -12,7 +12,10 @@ class TilesheetsEditSheetApi extends ApiBase {
     public function getAllowedParams() {
         return array(
             'token' => null,
-            'summary' => null,
+            'summary' => array(
+            	ParamValidator::PARAM_TYPE => 'string',
+            	ParamValidator::PARAM_DEFAULT => ''
+            ),
             'mod' => array(
                 ParamValidator::PARAM_TYPE => 'string',
                 ParamValidator::PARAM_REQUIRED => true,

--- a/api/TilesheetsEditTileApi.php
+++ b/api/TilesheetsEditTileApi.php
@@ -2,6 +2,7 @@
 
 use Wikimedia\Rdbms\ILoadBalancer;
 use MediaWiki\Permissions\PermissionManager;
+use Wikimedia\ParamValidator\ParamValidator;
 
 class TilesheetsEditTileApi extends ApiBase {
 	public function __construct($query, $moduleName, private ILoadBalancer $dbLoadBalancer, private PermissionManager $permissionManager) {
@@ -13,23 +14,23 @@ class TilesheetsEditTileApi extends ApiBase {
             'token' => null,
             'summary' => null,
             'id' => array(
-                ApiBase::PARAM_TYPE => 'integer',
-                ApiBase::PARAM_REQUIRED => true,
+                ParamValidator::PARAM_TYPE => 'integer',
+                ParamValidator::PARAM_REQUIRED => true,
             ),
             'toname' => array(
-                ApiBase::PARAM_TYPE => 'string',
+                ParamValidator::PARAM_TYPE => 'string',
             ),
             'tomod' => array(
-                ApiBase::PARAM_TYPE => 'string',
+                ParamValidator::PARAM_TYPE => 'string',
             ),
             'tox' => array(
-                ApiBase::PARAM_TYPE => 'integer',
+                ParamValidator::PARAM_TYPE => 'integer',
             ),
             'toy' => array(
-                ApiBase::PARAM_TYPE => 'integer',
+                ParamValidator::PARAM_TYPE => 'integer',
             ),
             'toz' => array(
-                Apibase::PARAM_TYPE => 'integer',
+                ParamValidator::PARAM_TYPE => 'integer',
             )
         );
     }

--- a/api/TilesheetsEditTileApi.php
+++ b/api/TilesheetsEditTileApi.php
@@ -5,7 +5,7 @@ use MediaWiki\Permissions\PermissionManager;
 use Wikimedia\ParamValidator\ParamValidator;
 
 class TilesheetsEditTileApi extends ApiBase {
-	public function __construct($query, $moduleName, private ILoadBalancer $dbLoadBalancer, private PermissionManager $permissionManager) {
+    public function __construct($query, $moduleName, private ILoadBalancer $dbLoadBalancer, private PermissionManager $permissionManager) {
         parent::__construct($query, $moduleName, 'ts');
     }
 

--- a/api/TilesheetsEditTileApi.php
+++ b/api/TilesheetsEditTileApi.php
@@ -1,7 +1,10 @@
 <?php
 
+use Wikimedia\Rdbms\ILoadBalancer;
+use MediaWiki\Permissions\PermissionManager;
+
 class TilesheetsEditTileApi extends ApiBase {
-    public function __construct($query, $moduleName) {
+	public function __construct($query, $moduleName, private ILoadBalancer $dbLoadBalancer, private PermissionManager $permissionManager) {
         parent::__construct($query, $moduleName, 'ts');
     }
 
@@ -85,7 +88,7 @@ class TilesheetsEditTileApi extends ApiBase {
         $toY = empty($toY) ? $row->y : $toY;
         $toZ = empty($toZ) ? $row->z : $toZ;
 
-        $result = TileManager::updateTable($id, $toName, $toMod, $toX, $toY, $toZ, $this->getUser(), $summary);
+        $result = TileManager::updateTable($id, $toName, $toMod, $toX, $toY, $toZ, $this->getUser(), $this->dbLoadBalancer, $summary);
         if ($result != 0) {
             $error = $result == 1 ? 'That entry does not exist' : 'There was no change';
             $this->dieWithError($error, 'updatefail');

--- a/api/TilesheetsEditTileApi.php
+++ b/api/TilesheetsEditTileApi.php
@@ -77,7 +77,7 @@ class TilesheetsEditTileApi extends ApiBase {
             $this->dieWithError('You have to specify one of tomod, toname, tox, toy, or toz', 'nochangeparams');
         }
 
-        $dbr = wfGetDB(DB_SLAVE);
+        $dbr = $this->dbLoadBalancer->getConnection(DB_REPLICA);
         $entry = $dbr->select('ext_tilesheet_items', '*', array('entry_id' => $id));
 
         if ($entry->numRows() == 0) {

--- a/api/TilesheetsEditTileApi.php
+++ b/api/TilesheetsEditTileApi.php
@@ -12,7 +12,10 @@ class TilesheetsEditTileApi extends ApiBase {
     public function getAllowedParams() {
         return array(
             'token' => null,
-            'summary' => null,
+            'summary' => array(
+            	ParamValidator::PARAM_TYPE => 'string',
+            	ParamValidator::PARAM_DEFAULT => ''
+            ),
             'id' => array(
                 ParamValidator::PARAM_TYPE => 'integer',
                 ParamValidator::PARAM_REQUIRED => true,

--- a/api/TilesheetsQuerySheetsApi.php
+++ b/api/TilesheetsQuerySheetsApi.php
@@ -1,22 +1,25 @@
 <?php
 
+use Wikimedia\Rdbms\ILoadBalancer;
+use Wikimedia\ParamValidator\ParamValidator;
+
 class TilesheetsQuerySheetsApi extends ApiQueryBase {
-    public function __construct($query, $moduleName) {
+    public function __construct($query, $moduleName, private ILoadBalancer $dbLoadBalancer) {
         parent::__construct($query, $moduleName, 'ts');
     }
 
     public function getAllowedParams() {
         return array(
             'limit' => array(
-                ApiBase::PARAM_DFLT => 10,
-                ApiBase::PARAM_TYPE => 'limit',
-                ApiBase::PARAM_MIN => 1,
-                ApiBase::PARAM_MAX => ApiBase::LIMIT_BIG1,
-                ApiBase::PARAM_MAX2 => ApiBase::LIMIT_BIG2,
+                ParamValidator::PARAM_DFLT => 10,
+                ParamValidator::PARAM_TYPE => 'limit',
+                ParamValidator::PARAM_MIN => 1,
+                ParamValidator::PARAM_MAX => ApiBase::LIMIT_BIG1,
+                ParamValidator::PARAM_MAX2 => ApiBase::LIMIT_BIG2,
             ),
             'from' => array(
-                ApiBase::PARAM_TYPE => 'string',
-                ApiBase::PARAM_DFLT => '',
+                ParamValidator::PARAM_TYPE => 'string',
+                ParamValidator::PARAM_DFLT => '',
             ),
         );
     }
@@ -31,7 +34,7 @@ class TilesheetsQuerySheetsApi extends ApiQueryBase {
     public function execute() {
         $limit = $this->getParameter('limit');
         $from = $this->getParameter('from');
-        $dbr = wfGetDB(DB_SLAVE);
+        $dbr = $this->dbLoadBalancer->getConnection(DB_REPLICA);
 
         $results = $dbr->select(
             'ext_tilesheet_images',

--- a/api/TilesheetsQuerySheetsApi.php
+++ b/api/TilesheetsQuerySheetsApi.php
@@ -11,7 +11,7 @@ class TilesheetsQuerySheetsApi extends ApiQueryBase {
     public function getAllowedParams() {
         return array(
             'limit' => array(
-                ParamValidator::PARAM_DFLT => 10,
+                ParamValidator::PARAM_DEFAULT => 10,
                 ParamValidator::PARAM_TYPE => 'limit',
                 ParamValidator::PARAM_MIN => 1,
                 ParamValidator::PARAM_MAX => ApiBase::LIMIT_BIG1,
@@ -19,7 +19,7 @@ class TilesheetsQuerySheetsApi extends ApiQueryBase {
             ),
             'from' => array(
                 ParamValidator::PARAM_TYPE => 'string',
-                ParamValidator::PARAM_DFLT => '',
+                ParamValidator::PARAM_DEFAULT => '',
             ),
         );
     }

--- a/api/TilesheetsQuerySheetsApi.php
+++ b/api/TilesheetsQuerySheetsApi.php
@@ -2,6 +2,7 @@
 
 use Wikimedia\Rdbms\ILoadBalancer;
 use Wikimedia\ParamValidator\ParamValidator;
+use Wikimedia\ParamValidator\TypeDef\IntegerDef;
 
 class TilesheetsQuerySheetsApi extends ApiQueryBase {
     public function __construct($query, $moduleName, private ILoadBalancer $dbLoadBalancer) {
@@ -13,9 +14,9 @@ class TilesheetsQuerySheetsApi extends ApiQueryBase {
             'limit' => array(
                 ParamValidator::PARAM_DEFAULT => 10,
                 ParamValidator::PARAM_TYPE => 'limit',
-                ParamValidator::PARAM_MIN => 1,
-                ParamValidator::PARAM_MAX => ApiBase::LIMIT_BIG1,
-                ParamValidator::PARAM_MAX2 => ApiBase::LIMIT_BIG2,
+                IntegerDef::PARAM_MIN => 1,
+                IntegerDef::PARAM_MAX => ApiBase::LIMIT_BIG1,
+                IntegerDef::PARAM_MAX2 => ApiBase::LIMIT_BIG2,
             ),
             'from' => array(
                 ParamValidator::PARAM_TYPE => 'string',

--- a/api/TilesheetsQueryTileUsagesApi.php
+++ b/api/TilesheetsQueryTileUsagesApi.php
@@ -3,6 +3,7 @@
 
 use Wikimedia\Rdbms\ILoadBalancer;
 use Wikimedia\ParamValidator\ParamValidator;
+use Wikimedia\ParamValidator\TypeDef\IntegerDef;
 
 class TilesheetsQueryTileUsagesApi extends ApiQueryBase {
 	public function __construct($query, $moduleName, private ILoadBalancer $dbLoadBalancer) {
@@ -14,9 +15,9 @@ class TilesheetsQueryTileUsagesApi extends ApiQueryBase {
 			'limit' => array(
 				ParamValidator::PARAM_DEFAULT => 10,
 				ParamValidator::PARAM_TYPE => 'limit',
-				ParamValidator::PARAM_MIN => 1,
-				ParamValidator::PARAM_MAX => ApiBase::LIMIT_BIG1,
-				ParamValidator::PARAM_MAX2 => ApiBase::LIMIT_BIG2,
+				IntegerDef::PARAM_MIN => 1,
+				IntegerDef::PARAM_MAX => ApiBase::LIMIT_BIG1,
+				IntegerDef::PARAM_MAX2 => ApiBase::LIMIT_BIG2,
 			),
 			'from' => array(
 				ParamValidator::PARAM_TYPE => 'integer',
@@ -25,7 +26,7 @@ class TilesheetsQueryTileUsagesApi extends ApiQueryBase {
 			'tile' => array(
 				ParamValidator::PARAM_TYPE => 'integer',
 				ParamValidator::PARAM_DEFAULT => 0,
-				ParamValidator::PARAM_MIN => 0
+				IntegerDef::PARAM_MIN => 0
 			),
 			'namespace' => array(
 				ParamValidator::PARAM_TYPE => 'namespace',

--- a/api/TilesheetsQueryTileUsagesApi.php
+++ b/api/TilesheetsQueryTileUsagesApi.php
@@ -1,32 +1,35 @@
 <?php
 
 
+use Wikimedia\Rdbms\ILoadBalancer;
+use Wikimedia\ParamValidator\ParamValidator;
+
 class TilesheetsQueryTileUsagesApi extends ApiQueryBase {
-	public function __construct($query, $moduleName) {
+	public function __construct($query, $moduleName, private ILoadBalancer $dbLoadBalancer) {
 		parent::__construct($query, $moduleName, 'ts');
 	}
 
 	public function getAllowedParams() {
 		return array(
 			'limit' => array(
-				ApiBase::PARAM_DFLT => 10,
-				ApiBase::PARAM_TYPE => 'limit',
-				ApiBase::PARAM_MIN => 1,
-				ApiBase::PARAM_MAX => ApiBase::LIMIT_BIG1,
-				ApiBase::PARAM_MAX2 => ApiBase::LIMIT_BIG2,
+				ParamValidator::PARAM_DFLT => 10,
+				ParamValidator::PARAM_TYPE => 'limit',
+				ParamValidator::PARAM_MIN => 1,
+				ParamValidator::PARAM_MAX => ApiBase::LIMIT_BIG1,
+				ParamValidator::PARAM_MAX2 => ApiBase::LIMIT_BIG2,
 			),
 			'from' => array(
-				ApiBase::PARAM_TYPE => 'integer',
-				ApiBase::PARAM_DFLT => 0,
+				ParamValidator::PARAM_TYPE => 'integer',
+				ParamValidator::PARAM_DFLT => 0,
 			),
 			'tile' => array(
-				ApiBase::PARAM_TYPE => 'integer',
-				ApiBase::PARAM_DFLT => 0,
-				ApiBase::PARAM_MIN => 0
+				ParamValidator::PARAM_TYPE => 'integer',
+				ParamValidator::PARAM_DFLT => 0,
+				ParamValidator::PARAM_MIN => 0
 			),
 			'namespace' => array(
-				ApiBase::PARAM_TYPE => 'namespace',
-				ApiBase::PARAM_ISMULTI => true
+				ParamValidator::PARAM_TYPE => 'namespace',
+				ParamValidator::PARAM_ISMULTI => true
 			)
 		);
 	}
@@ -43,7 +46,7 @@ class TilesheetsQueryTileUsagesApi extends ApiQueryBase {
 		$from = $this->getParameter('from');
 		$tileID = $this->getParameter('tile');
 		$namespaces = $this->getParameter('namespace');
-		$dbr = wfGetDB(DB_SLAVE);
+		$dbr = $this->dbLoadBalancer->getConnection(DB_REPLICA);
 
 		$conditions = array(
 			'tl_to = ' . intval($tileID),

--- a/api/TilesheetsQueryTileUsagesApi.php
+++ b/api/TilesheetsQueryTileUsagesApi.php
@@ -12,7 +12,7 @@ class TilesheetsQueryTileUsagesApi extends ApiQueryBase {
 	public function getAllowedParams() {
 		return array(
 			'limit' => array(
-				ParamValidator::PARAM_DFLT => 10,
+				ParamValidator::PARAM_DEFAULT => 10,
 				ParamValidator::PARAM_TYPE => 'limit',
 				ParamValidator::PARAM_MIN => 1,
 				ParamValidator::PARAM_MAX => ApiBase::LIMIT_BIG1,
@@ -20,11 +20,11 @@ class TilesheetsQueryTileUsagesApi extends ApiQueryBase {
 			),
 			'from' => array(
 				ParamValidator::PARAM_TYPE => 'integer',
-				ParamValidator::PARAM_DFLT => 0,
+				ParamValidator::PARAM_DEFAULT => 0,
 			),
 			'tile' => array(
 				ParamValidator::PARAM_TYPE => 'integer',
-				ParamValidator::PARAM_DFLT => 0,
+				ParamValidator::PARAM_DEFAULT => 0,
 				ParamValidator::PARAM_MIN => 0
 			),
 			'namespace' => array(

--- a/api/TilesheetsQueryTilesApi.php
+++ b/api/TilesheetsQueryTilesApi.php
@@ -1,26 +1,29 @@
 <?php
 
+use Wikimedia\ParamValidator\ParamValidator;
+use Wikimedia\Rdbms\ILoadBalancer;
+
 class TilesheetsQueryTilesApi extends ApiQueryBase {
-    public function __construct($query, $moduleName) {
+    public function __construct($query, $moduleName, private ILoadBalancer $dbLoadBalancer) {
         parent::__construct($query, $moduleName, 'ts');
     }
 
     public function getAllowedParams() {
         return array(
             'limit' => array(
-                ApiBase::PARAM_DFLT => 10,
-                ApiBase::PARAM_TYPE => 'limit',
-                ApiBase::PARAM_MIN => 1,
-                ApiBase::PARAM_MAX => ApiBase::LIMIT_BIG1,
-                ApiBase::PARAM_MAX2 => ApiBase::LIMIT_BIG2,
+                ParamValidator::PARAM_DFLT => 10,
+                ParamValidator::PARAM_TYPE => 'limit',
+                ParamValidator::PARAM_MIN => 1,
+                ParamValidator::PARAM_MAX => ApiBase::LIMIT_BIG1,
+                ParamValidator::PARAM_MAX2 => ApiBase::LIMIT_BIG2,
             ),
             'from' => array(
-                ApiBase::PARAM_TYPE => 'integer',
-                ApiBase::PARAM_DFLT => 0,
+                ParamValidator::PARAM_TYPE => 'integer',
+                ParamValidator::PARAM_DFLT => 0,
             ),
             'mod' => array(
-                ApiBase::PARAM_TYPE => 'string',
-                ApiBase::PARAM_DFLT => '',
+                ParamValidator::PARAM_TYPE => 'string',
+                ParamValidator::PARAM_DFLT => '',
             ),
         );
     }
@@ -36,7 +39,7 @@ class TilesheetsQueryTilesApi extends ApiQueryBase {
         $limit = $this->getParameter('limit');
         $from = $this->getParameter('from');
         $mod = $this->getParameter('mod');
-        $dbr = wfGetDB(DB_SLAVE);
+        $dbr = $this->dbLoadBalancer->getConnection(DB_REPLICA);
 
         $results = $dbr->select(
             'ext_tilesheet_items',

--- a/api/TilesheetsQueryTilesApi.php
+++ b/api/TilesheetsQueryTilesApi.php
@@ -2,6 +2,7 @@
 
 use Wikimedia\ParamValidator\ParamValidator;
 use Wikimedia\Rdbms\ILoadBalancer;
+use Wikimedia\ParamValidator\TypeDef\IntegerDef;
 
 class TilesheetsQueryTilesApi extends ApiQueryBase {
     public function __construct($query, $moduleName, private ILoadBalancer $dbLoadBalancer) {
@@ -13,9 +14,9 @@ class TilesheetsQueryTilesApi extends ApiQueryBase {
             'limit' => array(
                 ParamValidator::PARAM_DEFAULT => 10,
                 ParamValidator::PARAM_TYPE => 'limit',
-                ParamValidator::PARAM_MIN => 1,
-                ParamValidator::PARAM_MAX => ApiBase::LIMIT_BIG1,
-                ParamValidator::PARAM_MAX2 => ApiBase::LIMIT_BIG2,
+                IntegerDef::PARAM_MIN => 1,
+                IntegerDef::PARAM_MAX => ApiBase::LIMIT_BIG1,
+                IntegerDef::PARAM_MAX2 => ApiBase::LIMIT_BIG2,
             ),
             'from' => array(
                 ParamValidator::PARAM_TYPE => 'integer',

--- a/api/TilesheetsQueryTilesApi.php
+++ b/api/TilesheetsQueryTilesApi.php
@@ -11,7 +11,7 @@ class TilesheetsQueryTilesApi extends ApiQueryBase {
     public function getAllowedParams() {
         return array(
             'limit' => array(
-                ParamValidator::PARAM_DFLT => 10,
+                ParamValidator::PARAM_DEFAULT => 10,
                 ParamValidator::PARAM_TYPE => 'limit',
                 ParamValidator::PARAM_MIN => 1,
                 ParamValidator::PARAM_MAX => ApiBase::LIMIT_BIG1,
@@ -19,11 +19,11 @@ class TilesheetsQueryTilesApi extends ApiQueryBase {
             ),
             'from' => array(
                 ParamValidator::PARAM_TYPE => 'integer',
-                ParamValidator::PARAM_DFLT => 0,
+                ParamValidator::PARAM_DEFAULT => 0,
             ),
             'mod' => array(
                 ParamValidator::PARAM_TYPE => 'string',
-                ParamValidator::PARAM_DFLT => '',
+                ParamValidator::PARAM_DEFAULT => '',
             ),
         );
     }

--- a/api/TilesheetsQueryTranslationsApi.php
+++ b/api/TilesheetsQueryTranslationsApi.php
@@ -2,6 +2,7 @@
 
 use Wikimedia\Rdbms\ILoadBalancer;
 use Wikimedia\ParamValidator\ParamValidator;
+use Wikimedia\ParamValidator\TypeDef\IntegerDef;
 
 class TilesheetsQueryTranslationsApi extends ApiQueryBase {
     public function __construct($query, $moduleName, private ILoadBalancer $dbLoadBalancer) {
@@ -13,7 +14,7 @@ class TilesheetsQueryTranslationsApi extends ApiQueryBase {
             'id' => array(
                 ParamValidator::PARAM_TYPE => 'integer',
                 ParamValidator::PARAM_REQUIRED => true,
-                ParamValidator::PARAM_MIN => 1,
+                IntegerDef::PARAM_MIN => 1,
             ),
             'lang' => array(
                 ParamValidator::PARAM_TYPE => 'string',

--- a/api/TilesheetsQueryTranslationsApi.php
+++ b/api/TilesheetsQueryTranslationsApi.php
@@ -17,7 +17,7 @@ class TilesheetsQueryTranslationsApi extends ApiQueryBase {
             ),
             'lang' => array(
                 ParamValidator::PARAM_TYPE => 'string',
-                ParamValidator::PARAM_DFLT => '',
+                ParamValidator::PARAM_DEFAULT => '',
             )
         );
     }

--- a/api/TilesheetsQueryTranslationsApi.php
+++ b/api/TilesheetsQueryTranslationsApi.php
@@ -1,20 +1,23 @@
 <?php
 
+use Wikimedia\Rdbms\ILoadBalancer;
+use Wikimedia\ParamValidator\ParamValidator;
+
 class TilesheetsQueryTranslationsApi extends ApiQueryBase {
-    public function __construct($query, $moduleName) {
+    public function __construct($query, $moduleName, private ILoadBalancer $dbLoadBalancer) {
         parent::__construct($query, $moduleName, 'ts');
     }
 
     public function getAllowedParams() {
         return array(
             'id' => array(
-                ApiBase::PARAM_TYPE => 'integer',
-                ApiBase::PARAM_REQUIRED => true,
-                ApiBase::PARAM_MIN => 1,
+                ParamValidator::PARAM_TYPE => 'integer',
+                ParamValidator::PARAM_REQUIRED => true,
+                ParamValidator::PARAM_MIN => 1,
             ),
             'lang' => array(
-                ApiBase::PARAM_TYPE => 'string',
-                ApiBase::PARAM_DFLT => '',
+                ParamValidator::PARAM_TYPE => 'string',
+                ParamValidator::PARAM_DFLT => '',
             )
         );
     }
@@ -31,7 +34,7 @@ class TilesheetsQueryTranslationsApi extends ApiQueryBase {
         $id = $this->getParameter('id');
         $lang = $this->getParameter('lang');
 
-        $dbr = wfGetDB(DB_SLAVE);
+        $dbr = $this->dbLoadBalancer->getConnection(DB_REPLICA);
 
         $results = $dbr->select(
             'ext_tilesheet_languages',

--- a/api/TilesheetsTranslateTileApi.php
+++ b/api/TilesheetsTranslateTileApi.php
@@ -1,7 +1,11 @@
 <?php
 
+use Wikimedia\Rdbms\ILoadBalancer;
+use MediaWiki\Permissions\PermissionManager;
+use Wikimedia\ParamValidator\ParamValidator;
+
 class TilesheetsTranslateTileApi extends ApiBase {
-    public function __construct($query, $moduleName) {
+	public function __construct($query, $moduleName, private ILoadBalancer $dbLoadBalancer, private PermissionManager $permissionManager) {
         parent::__construct($query, $moduleName, 'ts');
     }
 
@@ -9,19 +13,19 @@ class TilesheetsTranslateTileApi extends ApiBase {
         return array(
             'token' => null,
             'id' => array(
-                ApiBase::PARAM_TYPE => 'integer',
-                ApiBase::PARAM_REQUIRED => true,
-                ApiBase::PARAM_MIN => 1,
+                ParamValidator::PARAM_TYPE => 'integer',
+                ParamValidator::PARAM_REQUIRED => true,
+                ParamValidator::PARAM_MIN => 1,
             ),
             'lang' => array(
-                ApiBase::PARAM_TYPE => 'string',
-                ApiBase::PARAM_REQUIRED => true,
+                ParamValidator::PARAM_TYPE => 'string',
+                ParamValidator::PARAM_REQUIRED => true,
             ),
             'name' => array(
-                ApiBase::PARAM_TYPE => 'string',
+                ParamValidator::PARAM_TYPE => 'string',
             ),
             'description' => array(
-                ApiBase::PARAM_TYPE => 'string',
+                ParamValidator::PARAM_TYPE => 'string',
             ),
         );
     }
@@ -49,7 +53,7 @@ class TilesheetsTranslateTileApi extends ApiBase {
     }
 
     public function execute() {
-        if (!in_array('translatetiles', $this->getUser()->getRights())) {
+    	if (!$this->permissionManager->userHasRight($this->getUser(), 'translatetiles')) {
             $this->dieWithError('You do not have permission to add tiles', 'permissiondenied');
         }
 
@@ -62,10 +66,10 @@ class TilesheetsTranslateTileApi extends ApiBase {
             $this->dieWithError('You have to specify one of name or description', 'nochangeparam');
         }
 
-        $dbr = wfGetDB(DB_SLAVE);
+        $dbr = $this->dbLoadBalancer->getConnection(DB_REPLICA);
         $stuff = $dbr->select('ext_tilesheet_languages', '*', array('entry_id' => $id, 'lang' => $lang));
 
-        TileTranslator::updateTable($id, $name, $desc, $lang, $this->getUser());
+        TileTranslator::updateTable($id, $name, $desc, $lang, $this->getUser(), $this->dbLoadBalancer);
         $ret = array(
             'entry_id' => $id,
             'language' => $lang,

--- a/api/TilesheetsTranslateTileApi.php
+++ b/api/TilesheetsTranslateTileApi.php
@@ -3,6 +3,7 @@
 use Wikimedia\Rdbms\ILoadBalancer;
 use MediaWiki\Permissions\PermissionManager;
 use Wikimedia\ParamValidator\ParamValidator;
+use Wikimedia\ParamValidator\TypeDef\IntegerDef;
 
 class TilesheetsTranslateTileApi extends ApiBase {
 	public function __construct($query, $moduleName, private ILoadBalancer $dbLoadBalancer, private PermissionManager $permissionManager) {
@@ -15,7 +16,7 @@ class TilesheetsTranslateTileApi extends ApiBase {
             'id' => array(
                 ParamValidator::PARAM_TYPE => 'integer',
                 ParamValidator::PARAM_REQUIRED => true,
-                ParamValidator::PARAM_MIN => 1,
+                IntegerDef::PARAM_MIN => 1,
             ),
             'lang' => array(
                 ParamValidator::PARAM_TYPE => 'string',

--- a/api/TilesheetsTranslateTileApi.php
+++ b/api/TilesheetsTranslateTileApi.php
@@ -6,7 +6,7 @@ use Wikimedia\ParamValidator\ParamValidator;
 use Wikimedia\ParamValidator\TypeDef\IntegerDef;
 
 class TilesheetsTranslateTileApi extends ApiBase {
-	public function __construct($query, $moduleName, private ILoadBalancer $dbLoadBalancer, private PermissionManager $permissionManager) {
+    public function __construct($query, $moduleName, private ILoadBalancer $dbLoadBalancer, private PermissionManager $permissionManager) {
         parent::__construct($query, $moduleName, 'ts');
     }
 
@@ -54,7 +54,7 @@ class TilesheetsTranslateTileApi extends ApiBase {
     }
 
     public function execute() {
-    	if (!$this->permissionManager->userHasRight($this->getUser(), 'translatetiles')) {
+        if (!$this->permissionManager->userHasRight($this->getUser(), 'translatetiles')) {
             $this->dieWithError('You do not have permission to add tiles', 'permissiondenied');
         }
 

--- a/extension.json
+++ b/extension.json
@@ -98,6 +98,7 @@
 		"Tilesheets": "Tilesheets.body.php",
 		"TilesheetsError": "Tilesheets.body.php",
 		"TilesheetsHooks": "Tilesheets.hooks.php",
+		"WhatUsesThisTileHooks": "hooks/WhatUsesThisTileHooks.php",
 		"TileList": "special/TileList.php",
 		"SheetList": "special/SheetList.php",
 		"CreateTileSheet": "special/CreateTileSheet.php",
@@ -220,31 +221,28 @@
 		"localBasePath": "/",
 		"remoteExtPath": "Tilesheets"
 	},
+	"HookHandlers": {
+		"main": {
+			"class": "TilesheetsHooks",
+			"services": [
+				"DBLoadBalancer"
+			]
+		},
+		"WhatUsesThisTileHooks": {
+			"class": "WhatUsesThisTileHooks",
+			"services": [
+				"DBLoadBalancer"
+			]
+		}
+	},
 	"Hooks": {
-		"ParserFirstCallInit": [
-			"TilesheetsHooks::SetupParser"
-		],
-		"BeforePageDisplay": [
-			"TilesheetsHooks::BeforePageDisplay"
-		],
-		"EditPage::showEditForm:initial": [
-			"TilesheetsHooks::OutputWarnings"
-		],
-		"OreDictOutput": [
-			"TilesheetsHooks::OreDictOutput"
-		],
-		"LoadExtensionSchemaUpdates": [
-			"TilesheetsHooks::SchemaUpdate"
-		],
-		"ArticleDeleteComplete": [
-			"TilesheetsHooks::onArticleDelete"
-		],
-		"PageContentSaveComplete": [
-			"TilesheetsHooks::addCacheToTileLinks"
-		],
-		"TitleMoveComplete": [
-			"TilesheetsHooks::onArticleMove"
-		]
+		"BeforePageDisplay": "main",
+		"EditPage::showEditForm:initial": "main",
+		"ParserFirstCallInit": "main",
+		"LoadExtensionSchemaUpdates": "main",
+		"PageDeleteComplete": "WhatUsesThisTileHooks",
+		"PageMoveComplete": "WhatUsesThisTileHooks",
+		"PageSaveComplete": "WhatUsesThisTileHooks"
 	},
 	"config": {
 		"ShowExceptionDetails": true,

--- a/extension.json
+++ b/extension.json
@@ -30,13 +30,15 @@
 		"TileList": {
 			"class": "TileList",
 			"services": [
-				"DBLoadBalancer"
+				"DBLoadBalancer",
+				"PermissionManager"
 			]
 		},
 		"SheetList": {
 			"class": "SheetList",
 			"services": [
-				"DBLoadBalancer"
+				"DBLoadBalancer",
+				"PermissionManager"
 			]
 		},
 		"CreateTileSheet": {

--- a/extension.json
+++ b/extension.json
@@ -27,14 +27,55 @@
 		}
 	},
 	"SpecialPages": {
-		"TileList": "TileList",
-		"SheetList": "SheetList",
-		"CreateTileSheet": "CreateTileSheet",
-		"TileManager": "TileManager",
-		"SheetManager": "SheetManager",
-		"TileTranslator": "TileTranslator",
-		"ViewTile": "ViewTile",
-		"WhatUsesThisTile": "WhatUsesThisTile"
+		"TileList": {
+			"class": "TileList",
+			"services": [
+				"DBLoadBalancer"
+			]
+		},
+		"SheetList": {
+			"class": "SheetList",
+			"services": [
+				"DBLoadBalancer"
+			]
+		},
+		"CreateTileSheet": {
+			"class": "CreateTileSheet",
+			"services": [
+				"DBLoadBalancer"
+			]
+		},
+		"TileManager": {
+			"class": "TileManager",
+			"services": [
+				"DBLoadBalancer"
+			]
+		},
+		"SheetManager": {
+			"class": "SheetManager",
+			"services": [
+				"DBLoadBalancer",
+				"UserGroupManager"
+			]
+		},
+		"TileTranslator": {
+			"class": "TileTranslator",
+			"services": [
+				"DBLoadBalancer"
+			]
+		},
+		"ViewTile": {
+			"class": "ViewTile",
+			"services": [
+				"DBLoadBalancer"
+			]
+		},
+		"WhatUsesThisTile": {
+			"class": "WhatUsesThisTile",
+			"services": [
+				"DBLoadBalancer"
+			]
+		}
 	},
 	"LogTypes": [
 		"tilesheet"
@@ -77,20 +118,88 @@
 		"TilesheetsTranslateTileApi": "api/TilesheetsTranslateTileApi.php"
 	},
 	"APIModules": {
-		"addtiles": "TilesheetsAddTilesApi",
-		"deletesheet": "TilesheetsDeleteSheetApi",
-		"createsheet": "TilesheetsAddSheetApi",
-		"deletetiles": "TilesheetsDeleteTilesApi",
-		"edittile": "TilesheetsEditTileApi",
-		"editsheet": "TilesheetsEditSheetApi",
-		"deletetranslation": "TilesheetsDeleteTranslationApi",
-		"translatetile": "TilesheetsTranslateTileApi"
+		"addtiles": {
+			"class": "TilesheetsAddTilesApi",
+			"services": [
+				"DBLoadBalancer",
+				"PermissionManager"
+			]
+		},
+		"deletesheet": {
+			"class": "TilesheetsDeleteSheetApi",
+			"services": [
+				"DBLoadBalancer",
+				"PermissionManager"
+			]
+			},
+		"createsheet": {
+			"class": "TilesheetsAddSheetApi",
+			"services": [
+				"DBLoadBalancer",
+				"PermissionManager"
+			]
+		},
+		"deletetiles": {
+			"class": "TilesheetsDeleteTilesApi",
+			"services": [
+				"DBLoadBalancer",
+				"PermissionManager"
+			]
+		},
+		"edittile": {
+			"class": "TilesheetsEditTileApi", 
+			"services": [
+				"DBLoadBalancer",
+				"PermissionManager"
+			]
+		},
+		"editsheet": {
+			"class": "TilesheetsEditSheetApi",
+			"services": [
+				"DBLoadBalancer",
+				"PermissionManager"
+			]
+		},
+		"deletetranslation": {
+			"class": "TilesheetsDeleteTranslationApi",
+			"services": [
+				"DBLoadBalancer",
+				"PermissionManager"
+			]
+		},
+		"translatetile": {
+			"class": "TilesheetsTranslateTileApi", 
+			"services": [
+				"DBLoadBalancer",
+				"PermissionManager"
+			]
+		}
 	},
 	"APIListModules": {
-		"tilesheets": "TilesheetsQuerySheetsApi",
-		"tiles": "TilesheetsQueryTilesApi",
-		"tiletranslations": "TilesheetsQueryTranslationsApi",
-		"tileusages": "TilesheetsQueryTileUsagesApi"
+		"tilesheets": {
+			"class": "TilesheetsQuerySheetsApi",
+			"services": [
+				"DBLoadBalancer"
+			]
+		},
+		"tiles": {
+			"class": "TilesheetsQueryTilesApi",
+			"services": [
+				"DBLoadBalancer"
+			]
+		},
+		"tiletranslations": {
+			"class": "TilesheetsQueryTranslationsApi",
+			"services": [
+				"DBLoadBalancer"
+			]
+		},
+		"tileusages": {
+			"class": "TilesheetsQueryTileUsagesApi",
+			"services": [
+				"DBLoadBalancer"
+			]
+		}
 	},
 	"ResourceModules": {
 		"ext.tilesheets": {

--- a/hooks/WhatUsesThisTileHooks.php
+++ b/hooks/WhatUsesThisTileHooks.php
@@ -1,0 +1,96 @@
+<?php
+
+use MediaWiki\Hook\PageMoveCompleteHook;
+use MediaWiki\Page\ProperPageIdentity;
+use MediaWiki\Page\Hook\PageDeleteCompleteHook;
+use MediaWiki\Permissions\Authority;
+use MediaWiki\Revision\RevisionRecord;
+use Wikimedia\Rdbms\ILoadBalancer;
+use MediaWiki\Storage\Hook\PageSaveCompleteHook;
+
+/**
+ * Handles all hooks relating to the WhatUsesThisTile feature.
+ * 
+ * Adds and removes entries to the ext_tilesheet_tilelinks table when pages are deleted, moved, or saved.
+ */
+class WhatUsesThisTileHooks implements PageDeleteCompleteHook, PageMoveCompleteHook, PageSaveCompleteHook {
+	/**
+	 * Specified in extension.json
+	 * @param ILoadBalancer $dbLoadBalancer
+	 */
+	public function __construct(private ILoadBalancer $dbLoadBalancer) {}
+	
+	public function onPageDeleteComplete(ProperPageIdentity $page, Authority $deleter, string $reason, int $pageID, RevisionRecord $deletedRev, ManualLogEntry $logEntry, int $archivedRevisionCount) {
+		$this->clearTileLinksForPage($page->getId(), $page->getNamespace());
+	}
+	
+	public function onPageMoveComplete($old, $new, $userIdentity, $pageID, $redirID, $reason, $revision) {
+		// It's worth noting that the ID doesn't change when pages are moved, according to Manual:Page table
+		// However, you can move pages across namespaces, so we still need to update the table.
+		$dbw = $this->dbLoadBalancer->getConnection(DB_PRIMARY);
+		$dbw->update(
+			'ext_tilesheet_tilelinks',
+			array('tl_from_namespace' => $new->getNamespace()),
+			array(
+				'tl_from' => $pageID,
+				'tl_from_namespace' => $old->getNamespace()
+			),
+			__METHOD__
+		);
+	}
+	
+	public function onPageSaveComplete($wikiPage, $user, $summary, $flags, $revisionRecord, $editResult) {
+		$pageID = $wikiPage->getId();
+		$namespace = $wikiPage->getNamespace();
+		$pageName = $wikiPage->getTitle()->getText();
+		
+		$this->clearTileLinksForPage($pageID, $namespace);
+		if (Tilesheets::$tileLinks[$namespace][$pageName] != null) {
+			array_unique(Tilesheets::$tileLinks[$namespace][$pageName]);
+			foreach (Tilesheets::$tileLinks[$namespace][$pageName] as $entryID) {
+				$this->addToTileLinks($pageID, $namespace, $entryID);
+			}
+		}
+		Tilesheets::$tileLinks[$namespace][$pageName] = array();
+		
+		return true;
+	}
+	
+	private function clearTileLinksForPage(int $pageID, int $namespaceID) {
+		$dbw = $this->dbLoadBalancer->getConnection(DB_PRIMARY);
+		$dbw->delete(
+			'ext_tilesheet_tilelinks', 
+			array(
+				'tl_from' => $pageID, 
+				'tl_from_namespace' => $namespaceID
+			)
+		);
+	}
+	
+	private function addToTileLinks(int $pageID, int $namespaceID, int $tileID) {
+		$dbw = $this->dbLoadBalancer->getConnection(DB_PRIMARY);
+		
+		$result = $dbw->select(
+			'ext_tilesheet_tilelinks', 
+			'COUNT(`tl_to`) AS count', 
+			array(
+				'tl_from' => $pageID,
+				'tl_from_namespace' => $namespaceID,
+				'tl_to' => $tileID
+			)
+		);
+		
+		if ($result->current()->count == 0) {
+			$dbw->insert(
+				'ext_tilesheet_tilelinks', 
+				array(
+					'tl_from' => $pageID,
+					'tl_from_namespace' => $namespaceID,
+					'tl_to' => $tileID
+				),
+				__METHOD__
+			);
+		}
+	}
+}
+

--- a/special/CreateTileSheet.php
+++ b/special/CreateTileSheet.php
@@ -140,7 +140,6 @@ class CreateTileSheet extends SpecialPage {
             ->setWrapperLegendMsg('tilesheet-create-legend')
             ->setId('ext-tilesheet-create-form')
             ->setSubmitTextMsg('tilesheet-create-submit')
-            ->setSubmitProgressive()
             ->prepareForm()
             ->displayForm(false);
 	}

--- a/special/CreateTileSheet.php
+++ b/special/CreateTileSheet.php
@@ -1,4 +1,6 @@
 <?php
+use Wikimedia\Rdbms\ILoadBalancer;
+
 /**
  * CreateTileSheet special page file
  *
@@ -13,7 +15,7 @@ class CreateTileSheet extends SpecialPage {
 	/**
 	 * Calls parent constructor and sets special page title
 	 */
-	public function __construct() {
+	public function __construct(private ILoadBalancer $dbLoadBalancer) {
 		parent::__construct('CreateTileSheet', 'importtilesheets');
 	}
 
@@ -70,13 +72,13 @@ class CreateTileSheet extends SpecialPage {
 			// If update mode
 			if ($opts->getValue('update_table') == 1) {
 				// Delete sheet
-				$out->addHtml($this->returnMessage(SheetManager::deleteEntry($mod, $this->getUser(), $this->msg('tilesheet-create-summary-deletesheet')->text()), $this->msg('tilesheet-create-response-msg-deletesheet')->text()));
+				$out->addHtml($this->returnMessage(SheetManager::deleteEntry($mod, $this->getUser(), $this->dbLoadBalancer, $this->msg('tilesheet-create-summary-deletesheet')->text()), $this->msg('tilesheet-create-response-msg-deletesheet')->text()));
 				// Truncate table
 				$out->addHtml($this->returnMessage(SheetManager::truncateTable($mod, $this->getUser(), $this->msg('tilesheet-create-summary-deletesheet')->text()), $this->msg('tilesheet-create-response-msg-truncate')->text()));
 			}
 
 			// Create sheet
-			$out->addHtml($this->returnMessage(SheetManager::createSheet($mod, $sizes, $this->getUser()), $this->msg('tilesheet-create-response-msg-newsheet')->text()));
+			$out->addHtml($this->returnMessage(SheetManager::createSheet($mod, $sizes, $this->getUser(), $this->dbLoadBalancer), $this->msg('tilesheet-create-response-msg-newsheet')->text()));
 
 			$input = explode("\n", trim($opts->getValue('input')));
 			foreach ($input as $line) {
@@ -85,7 +87,7 @@ class CreateTileSheet extends SpecialPage {
 				$item = trim($item);
 
 				// Create tile
-				$out->addHtml($this->returnMessage(TileManager::createTile($mod, $item, $x, $y, $z, $this->getUser(), $this->msg('tilesheet-create-summary-newtile')->text()), $this->msg('tilesheet-create-response-msg-newtile')->params($item, $mod, $x, $y, $z)->text()));
+				$out->addHtml($this->returnMessage(TileManager::createTile($mod, $item, $x, $y, $z, $this->getUser(), $this->dbLoadBalancer, $this->msg('tilesheet-create-summary-newtile')->text()), $this->msg('tilesheet-create-response-msg-newtile')->params($item, $mod, $x, $y, $z)->text()));
 			}
 		$out->addHtml('</tt>');
 		} else {

--- a/special/CreateTileSheet.php
+++ b/special/CreateTileSheet.php
@@ -74,7 +74,7 @@ class CreateTileSheet extends SpecialPage {
 				// Delete sheet
 				$out->addHtml($this->returnMessage(SheetManager::deleteEntry($mod, $this->getUser(), $this->dbLoadBalancer, $this->msg('tilesheet-create-summary-deletesheet')->text()), $this->msg('tilesheet-create-response-msg-deletesheet')->text()));
 				// Truncate table
-				$out->addHtml($this->returnMessage(SheetManager::truncateTable($mod, $this->getUser(), $this->msg('tilesheet-create-summary-deletesheet')->text()), $this->msg('tilesheet-create-response-msg-truncate')->text()));
+				$out->addHtml($this->returnMessage(SheetManager::truncateTable($mod, $this->getUser(), $this->dbLoadBalancer, $this->msg('tilesheet-create-summary-deletesheet')->text()), $this->msg('tilesheet-create-response-msg-truncate')->text()));
 			}
 
 			// Create sheet

--- a/special/SheetList.php
+++ b/special/SheetList.php
@@ -81,7 +81,7 @@ class SheetList extends SpecialPage {
 
 		if ($maxRows == 0) {
 			$this->displayFilterForm($opts);
-			$out->addWikiText($this->msg('tilesheet-fail-norows')->text());
+			$out->addWikiTextAsInterface($this->msg('tilesheet-fail-norows')->text());
 			return;
 		}
 
@@ -138,8 +138,8 @@ class SheetList extends SpecialPage {
 
 		// Output page
 		$this->displayFilterForm($opts);
-		$out->addWikiText($pageSelection);
-		$out->addWikiText($table);
+		$out->addWikiTextAsInterface($pageSelection);
+		$out->addWikiTextAsInterface($table);
 	}
 
 	private function displayFilterForm(FormOptions $opts) {

--- a/special/SheetList.php
+++ b/special/SheetList.php
@@ -1,5 +1,6 @@
 <?php
 use Wikimedia\Rdbms\ILoadBalancer;
+use MediaWiki\Permissions\PermissionManager;
 
 /**
  * SheetsList special page file
@@ -15,7 +16,7 @@ class SheetList extends SpecialPage {
 	/**
 	 * Calls parent constructor and sets special page title
 	 */
-	public function __construct(private ILoadBalancer $dbLoadBalancer) {
+	public function __construct(private ILoadBalancer $dbLoadBalancer, private PermissionManager $permissionManager) {
 		parent::__construct('SheetList');
 	}
 
@@ -89,7 +90,7 @@ class SheetList extends SpecialPage {
 		$table = "{| class=\"mw-datatable\" style=\"width:100%\"\n";
 		$msgModName = wfMessage('tilesheet-mod-name');
 		$msgSizesName = wfMessage('tilesheet-sizes');
-		$canEdit = in_array("edittilesheets", $this->getUser()->getRights());
+		$canEdit = $this->permissionManager->userHasRight($this->getUser(), 'edittilesheets');
 		$table .= "!";
 		if ($canEdit) {
 			$table .= " !!";

--- a/special/SheetList.php
+++ b/special/SheetList.php
@@ -1,4 +1,6 @@
 <?php
+use Wikimedia\Rdbms\ILoadBalancer;
+
 /**
  * SheetsList special page file
  *
@@ -13,7 +15,7 @@ class SheetList extends SpecialPage {
 	/**
 	 * Calls parent constructor and sets special page title
 	 */
-	public function __construct() {
+	public function __construct(private ILoadBalancer $dbLoadBalancer) {
 		parent::__construct('SheetList');
 	}
 
@@ -54,7 +56,7 @@ class SheetList extends SpecialPage {
 		$page = intval($opts->getValue('page'));
 
 		// Load data
-		$dbr = wfGetDB(DB_SLAVE);
+		$dbr = $this->dbLoadBalancer->getConnection(DB_REPLICA);
 		$result = $dbr->select(
 			'ext_tilesheet_images',
 			'COUNT(`mod`) AS row_count'

--- a/special/SheetList.php
+++ b/special/SheetList.php
@@ -166,7 +166,6 @@ class SheetList extends SpecialPage {
             ->setWrapperLegendMsg('tilesheet-sheet-list-legend')
             ->setId('ext-tilesheet-sheet-list-filter')
             ->setSubmitTextMsg('tilesheet-sheet-list-submit')
-            ->setSubmitProgressive()
             ->prepareForm()
             ->displayForm(false);
 	}

--- a/special/SheetManager.php
+++ b/special/SheetManager.php
@@ -1,4 +1,8 @@
 <?php
+
+use Wikimedia\Rdbms\ILoadBalancer;
+use MediaWiki\User\UserGroupManager;
+
 /**
  * SheetManager special page file
  *
@@ -13,7 +17,7 @@ class SheetManager extends SpecialPage {
 	/**
 	 * Calls parent constructor and sets special page title
 	 */
-	public function __construct() {
+	public function __construct(private ILoadBalancer $dbLoadBalancer, private UserGroupManager $groupManager) {
 		parent::__construct('SheetManager', 'edittilesheets');
 	}
 
@@ -65,11 +69,13 @@ class SheetManager extends SpecialPage {
 		$out->addHTML($this->buildSearchForm());
 
 		if ($mod == '') return;
+		
+		$userGroups = $this->groupManager->getUserGroups($this->getUser());
 
 		// Update stuff
-		if ($opts->getValue('update') == 1) Tilesheets::updateSheetRow($mod, $mod, $sizes, $this->getUser());
-		if ($opts->getValue('delete') == 1 && in_array('sysop', $this->getUser()->getGroups())) self::deleteEntry($mod, $this->getUser());
-		if ($opts->getValue('truncate') == 1 || $opts->getValue('delete') == 1 && in_array('sysop', $this->getUser()->getGroups())) self::truncateTable($mod, $this->getUser());
+		if ($opts->getValue('update') == 1) Tilesheets::updateSheetRow($mod, $mod, $sizes, $this->getUser(), $this->dbLoadBalancer);
+		if ($opts->getValue('delete') == 1 && in_array('sysop', $userGroups)) self::deleteEntry($mod, $this->getUser(), $this->dbLoadBalancer);
+		if ($opts->getValue('truncate') == 1 || $opts->getValue('delete') == 1 && in_array('sysop', $userGroups)) self::truncateTable($mod, $this->getUser());
 
 		// Output update table
 		$this->displayUpdateForm($mod);
@@ -79,12 +85,13 @@ class SheetManager extends SpecialPage {
 	 * Delete the entry provided
 	 *
 	 * @param string $mod
-	 * @param $comment
 	 * @param User $user
+	 * @param ILoadBalancer $dbLoadBalancer
+	 * @param $comment
 	 * @return  bool
 	 */
-	public static function deleteEntry($mod, $user, $comment = "") {
-		$dbw = wfGetDB(DB_MASTER);
+	public static function deleteEntry($mod, $user, ILoadBalancer $dbLoadBalancer, $comment = "") {
+		$dbw = $dbLoadBalancer->getConnection(DB_PRIMARY);
 		$stuff = $dbw->select('ext_tilesheet_images', '*', array('`mod`' => $mod));
 		$result = $dbw->delete('ext_tilesheet_images', array('`mod`' => $mod));
 
@@ -138,8 +145,8 @@ class SheetManager extends SpecialPage {
 		return true;
 	}
 
-	public static function createSheet($mod, $sizes, $user, $comment = "") {
-		$dbw = wfGetDB(DB_MASTER);
+	public static function createSheet($mod, $sizes, $user, ILoadBalancer $dbLoadBalancer, $comment = "") {
+		$dbw = $dbLoadBalancer->getConnection(DB_PRIMARY);
 		// Check if already exists
 		$result = $dbw->select('ext_tilesheet_images', 'COUNT(`mod`) AS count', array('`mod`' => $mod));
 

--- a/special/SheetManager.php
+++ b/special/SheetManager.php
@@ -75,7 +75,7 @@ class SheetManager extends SpecialPage {
 		// Update stuff
 		if ($opts->getValue('update') == 1) Tilesheets::updateSheetRow($mod, $mod, $sizes, $this->getUser(), $this->dbLoadBalancer);
 		if ($opts->getValue('delete') == 1 && in_array('sysop', $userGroups)) self::deleteEntry($mod, $this->getUser(), $this->dbLoadBalancer);
-		if ($opts->getValue('truncate') == 1 || $opts->getValue('delete') == 1 && in_array('sysop', $userGroups)) self::truncateTable($mod, $this->getUser());
+		if ($opts->getValue('truncate') == 1 || $opts->getValue('delete') == 1 && in_array('sysop', $userGroups)) self::truncateTable($mod, $this->getUser(), $this->dbLoadBalancer);
 
 		// Output update table
 		$this->displayUpdateForm($mod);
@@ -120,8 +120,8 @@ class SheetManager extends SpecialPage {
 	 * @param User $user
 	 * @return bool
 	 */
-	public static function truncateTable($mod, $user, $comment = "") {
-		$dbw = wfGetDB(DB_MASTER);
+	public static function truncateTable($mod, $user, ILoadBalancer $dbLoadBalancer, $comment = "") {
+		$dbw = $dbLoadBalancer->getConnection(DB_PRIMARY);
 		$stuff = $dbw->select('ext_tilesheet_items', '*', array('mod_name' => $mod));
 		$result = $dbw->delete('ext_tilesheet_items', array('mod_name' => $mod));
 
@@ -213,7 +213,7 @@ class SheetManager extends SpecialPage {
 	}
 
 	private function displayUpdateForm($mod) {
-		$dbr = wfGetDB(DB_SLAVE);
+		$dbr = $this->dbLoadBalancer->getConnection(DB_REPLICA);
 		$result = $dbr->select('ext_tilesheet_images', '*', array('`mod`' => $mod));
 		if ($result->numRows() == 0) {
 			return $this->msg('tilesheet-fail-norows')->text();

--- a/special/TileList.php
+++ b/special/TileList.php
@@ -1,4 +1,6 @@
 <?php
+use Wikimedia\Rdbms\ILoadBalancer;
+
 /**
  * TileList special page file
  *
@@ -13,7 +15,7 @@ class TileList extends SpecialPage {
 	/**
 	 * Calls parent constructor and sets special page title
 	 */
-	public function __construct() {
+	public function __construct(private ILoadBalancer $dbLoadBalancer) {
 		parent::__construct('TileList');
 	}
 
@@ -64,7 +66,7 @@ class TileList extends SpecialPage {
 		$from = intval($opts->getValue('from'));
 
 		// Load data
-		$dbr = wfGetDB(DB_SLAVE);
+		$dbr = $this->dbLoadBalancer->getConnection(DB_REPLICA);
 		$formattedEntryIDs = '';
 
 		if (!empty($langs)) {

--- a/special/TileList.php
+++ b/special/TileList.php
@@ -1,5 +1,6 @@
 <?php
 use Wikimedia\Rdbms\ILoadBalancer;
+use MediaWiki\Permissions\PermissionManager;
 
 /**
  * TileList special page file
@@ -15,7 +16,7 @@ class TileList extends SpecialPage {
 	/**
 	 * Calls parent constructor and sets special page title
 	 */
-	public function __construct(private ILoadBalancer $dbLoadBalancer) {
+	public function __construct(private ILoadBalancer $dbLoadBalancer, private PermissionManager $permissionManager) {
 		parent::__construct('TileList');
 	}
 
@@ -148,8 +149,8 @@ class TileList extends SpecialPage {
 		$msgXName = wfMessage('tilesheet-x');
 		$msgYName = wfMessage('tilesheet-y');
 		$msgZName = wfMessage('tilesheet-z');
-		$canEdit = in_array("edittilesheets", $this->getUser()->getRights());
-		$canTranslate = in_array('translatetiles', $this->getUser()->getRights());
+		$canEdit = $this->permissionManager->userHasRight($this->getUser(), 'edittilesheets');
+		$canTranslate = $this->permissionManager->userHasRight($this->getUser(), 'translatetiles');
 		$table .= "!";
 		if ($canEdit) {
 			$table .= " !!";

--- a/special/TileList.php
+++ b/special/TileList.php
@@ -287,7 +287,6 @@ class TileList extends SpecialPage {
             ->setWrapperLegendMsg('tilesheet-tile-list-legend')
             ->setId('ext-tilesheet-tile-list-filter')
             ->setSubmitTextMsg('tilesheet-tile-list-submit')
-            ->setSubmitProgressive()
             ->prepareForm()
             ->displayForm(false);
     }

--- a/special/TileList.php
+++ b/special/TileList.php
@@ -136,7 +136,7 @@ class TileList extends SpecialPage {
 
 		if ($maxRows == 0) {
 		    $this->displayFilterForm($opts);
-			$out->addWikiText($this->msg('tilesheet-fail-norows')->text());
+			$out->addWikiTextAsInterface($this->msg('tilesheet-fail-norows')->text());
 			return;
 		}
 
@@ -226,8 +226,8 @@ class TileList extends SpecialPage {
 
         // Output page
         $this->displayFilterForm($opts);
-		$out->addWikiText($pageSelection);
-		$out->addWikiText($table);
+		$out->addWikiTextAsInterface($pageSelection);
+		$out->addWikiTextAsInterface($table);
 	}
 
 	private function displayFilterForm(FormOptions $opts) {

--- a/special/TileManager.php
+++ b/special/TileManager.php
@@ -256,7 +256,7 @@ class TileManager extends SpecialPage {
 	}
 
 	private function displayUpdateForm($id) {
-		$dbr = wfGetDB(DB_SLAVE);
+		$dbr = $this->dbLoadBalancer->getConnection(DB_REPLICA);
 		$result = $dbr->select('ext_tilesheet_items', '*', array('entry_id' => $id));
 		if ($result->numRows() == 0) {
 			return $this->msg('tilesheet-fail-norows')->text();

--- a/special/TileManager.php
+++ b/special/TileManager.php
@@ -321,7 +321,6 @@ class TileManager extends SpecialPage {
             ->setWrapperLegendMsg('tilesheet-tile-manager-legend')
             ->setId('ext-tilesheet-tile-manager-form')
             ->setSubmitTextMsg('tilesheet-tile-manager-submit')
-            ->setSubmitProgressive()
             ->prepareForm()
             ->displayForm(false);
 	}

--- a/special/ViewTile.php
+++ b/special/ViewTile.php
@@ -1,7 +1,9 @@
 <?php
 
+use Wikimedia\Rdbms\ILoadBalancer;
+
 class ViewTile extends SpecialPage {
-	public function __construct() {
+	public function __construct(private ILoadBalancer $dbLoadBalancer) {
 		parent::__construct('ViewTile');
 	}
 
@@ -16,7 +18,7 @@ class ViewTile extends SpecialPage {
 		$out->addModuleStyles('ext.tilesheets.special');
 		$out->addModules('ext.tilesheets.viewtile');
 
-		$dbr = wfGetDB(DB_SLAVE);
+		$dbr = $this->dbLoadBalancer->getConnection(DB_REPLICA);
 		$result = $dbr->select('ext_tilesheet_items', '*', array('entry_id' => $subPage));
 		if ($result->numRows() == 0) {
 			$out->addWikiText($this->msg('tilesheet-fail-norows')->text());

--- a/special/ViewTile.php
+++ b/special/ViewTile.php
@@ -21,13 +21,13 @@ class ViewTile extends SpecialPage {
 		$dbr = $this->dbLoadBalancer->getConnection(DB_REPLICA);
 		$result = $dbr->select('ext_tilesheet_items', '*', array('entry_id' => $subPage));
 		if ($result->numRows() == 0) {
-			$out->addWikiText($this->msg('tilesheet-fail-norows')->text());
+			$out->addWikiTextAsInterface($this->msg('tilesheet-fail-norows')->text());
 		} else {
 			$item = $result->current()->item_name;
 			$mod = $result->current()->mod_name;
 
 			$itemFromMod = wfMessage('tilesheet-tile-viewer-header', $item, $mod);
-			$out->addWikiText("== $itemFromMod ==\n\n");
+			$out->addWikiTextAsInterface("== $itemFromMod ==\n\n");
 
 			$sizeText = wfMessage('tilesheet-tile-viewer-size');
 			$tileText = wfMessage('tilesheet-tile-viewer-tile');
@@ -42,7 +42,7 @@ class ViewTile extends SpecialPage {
 			}
 			$outText .= "|}";
 
-			$out->addWikiText($outText);
+			$out->addWikiTextAsInterface($outText);
 		}
 	}
 }

--- a/special/WhatUsesThisTile.php
+++ b/special/WhatUsesThisTile.php
@@ -1,9 +1,11 @@
 <?php
 
+use Wikimedia\Rdbms\ILoadBalancer;
+
 class WhatUsesThisTile extends SpecialPage {
 	private $target;
 
-	public function __construct() {
+	public function __construct(private ILoadBalancer $dbLoadBalancer) {
 		parent::__construct('WhatUsesThisTile');
 	}
 
@@ -38,7 +40,7 @@ class WhatUsesThisTile extends SpecialPage {
 		$page = intval($opts->getValue('page'));
 		$from = intval($opts->getValue('from'));
 
-		$dbr = wfGetDB(DB_SLAVE);
+		$dbr = $this->dbLoadBalancer->getConnection(DB_REPLICA);
 		$tileData = $dbr->select('ext_tilesheet_items', '*', array('entry_id' => $entryID));
 		$out->addBacklinkSubtitle(Title::newFromText("ViewTile/$entryID", NS_SPECIAL));
 		if ($tileData->numRows() == 0) {

--- a/special/WhatUsesThisTile.php
+++ b/special/WhatUsesThisTile.php
@@ -22,7 +22,7 @@ class WhatUsesThisTile extends SpecialPage {
 		// Require subpage syntax. Nobody memorizes entry IDs.
 		if (empty($entryID)) {
 			$out->setPageTitle($this->msg('tilesheet-whatusesthistile-title-noid'));
-			$out->addWikiText($this->msg('tilesheet-whatusesthistile-noid'));
+			$out->addWikiTextAsInterface($this->msg('tilesheet-whatusesthistile-noid'));
 			return;
 		}
 
@@ -45,7 +45,7 @@ class WhatUsesThisTile extends SpecialPage {
 		$out->addBacklinkSubtitle(Title::newFromText("ViewTile/$entryID", NS_SPECIAL));
 		if ($tileData->numRows() == 0) {
 			$out->setPageTitle($this->msg('tilesheet-whatusesthistile-title', $entryID));
-			$out->addWikiText($this->msg('tilesheet-whatusesthistile-notile', $entryID));
+			$out->addWikiTextAsInterface($this->msg('tilesheet-whatusesthistile-notile', $entryID));
 			return;
 		} else {
 			$name = $tileData->current()->item_name;
@@ -69,10 +69,10 @@ class WhatUsesThisTile extends SpecialPage {
 			);
 
 			if ($results->numRows() == 0) {
-				$out->addWikiText($this->msg('tilesheet-whatusesthistile-none', $name));
+				$out->addWikiTextAsInterface($this->msg('tilesheet-whatusesthistile-none', $name));
 				return;
 			} else {
-				$out->addWikiText($this->msg('tilesheet-whatusesthistile-some', $name));
+				$out->addWikiTextAsInterface($this->msg('tilesheet-whatusesthistile-some', $name));
 
 				$rows = [];
 				foreach ($results as $row) {


### PR DESCRIPTION
Resolves #111 and #97 

Updates APIs and special pages to use new dependency injection with specifications in `extension.json`.

Updates hooks to use new hookhandler system. The OreDict hook is untouched. That extension will have to be updated, and then Tilesheets may need to be updated again. Not exactly sure what changes OreDict will need yet.

Hooks for the tilelinks system are moved into their own handler class separate from our generic hook handler.