### PR TITLE
Add imports for namespaced classes (1.44 compatibility)

### DIFF
--- a/Tilesheets.body.php
+++ b/Tilesheets.body.php
@@ -1,4 +1,6 @@
 <?php
+
+use MediaWiki\Title\Title;
 use Wikimedia\Rdbms\ILoadBalancer;
 use MediaWiki\MediaWikiServices;
 
@@ -135,7 +137,7 @@ class Tilesheets {
 				$size = min(self::$mQueriedSizes[$mod]);
 			}
 		}
-		
+
 		// New pages do not have an article ID, so we have to store it in the title and then get the ID when updating the db
 		$pageRef = $parser->getPage();
 		self::$tileLinks[$pageRef->getNamespace()][$pageRef->getText()][] = $entryID;

--- a/Tilesheets.hooks.php
+++ b/Tilesheets.hooks.php
@@ -1,4 +1,6 @@
 <?php
+
+use MediaWiki\EditPage\EditPage;
 use MediaWiki\MediaWikiServices;
 use OreDict\Hook\OreDictOutputHook;
 use MediaWiki\Hook\BeforePageDisplayHook;
@@ -31,7 +33,7 @@ class TilesheetsHooks implements ParserFirstCallInitHook, BeforePageDisplayHook,
 
 		return true;
 	}
-	
+
 	/**
 	 * Handler for BeforePageDisplay hook.
 	 * @see http://www.mediawiki.org/wiki/Manual:Hooks/BeforePageDisplay
@@ -79,11 +81,11 @@ class TilesheetsHooks implements ParserFirstCallInitHook, BeforePageDisplayHook,
 			->from('ext_tilesheet_items')
 			->where(array('item_name' => $item, 'mod_name' => $mod))
 			->fetchRow();
-		
+
 		if (!$resultItem) {
 			return $type == 'name' ? $item : '';
 		}
-		
+
 		$loc = $dbr->newSelectQueryBuilder()
 			->select('*')
 			->from('ext_tilesheet_languages')

--- a/extension.json
+++ b/extension.json
@@ -13,6 +13,9 @@
 	"url": "http://help.gamepedia.com/Extension:Tilesheets",
 	"descriptionmsg": "tilesheets-desc",
 	"type": "parserhook",
+	"requires": {
+		"MediaWiki": ">= 1.40.0"
+	},
 	"license-name": "MIT",
 	"AvailableRights": [
 		"edittilesheets",
@@ -151,7 +154,7 @@
 			]
 		},
 		"edittile": {
-			"class": "TilesheetsEditTileApi", 
+			"class": "TilesheetsEditTileApi",
 			"services": [
 				"DBLoadBalancer",
 				"PermissionManager"
@@ -172,7 +175,7 @@
 			]
 		},
 		"translatetile": {
-			"class": "TilesheetsTranslateTileApi", 
+			"class": "TilesheetsTranslateTileApi",
 			"services": [
 				"DBLoadBalancer",
 				"PermissionManager"

--- a/special/CreateTileSheet.php
+++ b/special/CreateTileSheet.php
@@ -1,4 +1,6 @@
 <?php
+
+use MediaWiki\Html\FormOptions;
 use Wikimedia\Rdbms\ILoadBalancer;
 
 /**

--- a/special/SheetList.php
+++ b/special/SheetList.php
@@ -1,4 +1,6 @@
 <?php
+
+use MediaWiki\Html\FormOptions;
 use Wikimedia\Rdbms\ILoadBalancer;
 use MediaWiki\Permissions\PermissionManager;
 

--- a/special/SheetManager.php
+++ b/special/SheetManager.php
@@ -1,5 +1,8 @@
 <?php
 
+use MediaWiki\Html\FormOptions;
+use MediaWiki\Html\Html;
+use MediaWiki\Title\Title;
 use Wikimedia\Rdbms\ILoadBalancer;
 use MediaWiki\User\UserGroupManager;
 
@@ -69,7 +72,7 @@ class SheetManager extends SpecialPage {
 		$out->addHTML($this->buildSearchForm());
 
 		if ($mod == '') return;
-		
+
 		$userGroups = $this->groupManager->getUserGroups($this->getUser());
 
 		// Update stuff
@@ -97,11 +100,11 @@ class SheetManager extends SpecialPage {
 			->from('ext_tilesheet_images')
 			->where(array('`mod`' => $mod))
 			->fetchRow();
-		
+
 		if (!$row) {
 			return false;
 		}
-		
+
 		try {
 			$dbw->newDeleteQueryBuilder()
 				->deleteFrom('ext_tilesheet_images')
@@ -139,9 +142,9 @@ class SheetManager extends SpecialPage {
 			->from('ext_tilesheet_items')
 			->where(array('`mod_name`' => $mod))
 			->fetchResultSet();
-		
+
 		if ($stuff->numRows() == 0) return false;
-		
+
 		try {
 			$dbw->newDeleteQueryBuilder()
 				->deleteFrom('ext_tilesheet_items')

--- a/special/TileList.php
+++ b/special/TileList.php
@@ -1,4 +1,6 @@
 <?php
+
+use MediaWiki\Html\FormOptions;
 use Wikimedia\Rdbms\ILoadBalancer;
 use MediaWiki\Permissions\PermissionManager;
 

--- a/special/TileManager.php
+++ b/special/TileManager.php
@@ -1,4 +1,8 @@
 <?php
+
+use MediaWiki\Html\FormOptions;
+use MediaWiki\Html\Html;
+use MediaWiki\Title\Title;
 use Wikimedia\Rdbms\ILoadBalancer;
 
 /**
@@ -142,7 +146,7 @@ class TileManager extends SpecialPage {
 			->where(array('entry_id' => $id))
 			->fetchResultSet();
 		if ($stuff->numRows() == 0) return false;
-		
+
 		try {
 			$dbw->newDeleteQueryBuilder()
 				->deleteFrom('ext_tilesheet_items')
@@ -190,7 +194,7 @@ class TileManager extends SpecialPage {
 			->where(array('entry_id' => $id))
 			->fetchResultSet();
 		if ($stuff->numRows() == 0) return 1;
-		
+
 		try {
 			$dbw->newUpdateQueryBuilder()
 				->update('ext_tilesheet_items')

--- a/special/TileTranslator.php
+++ b/special/TileTranslator.php
@@ -1,5 +1,7 @@
 <?php
 
+use MediaWiki\Html\FormOptions;
+use MediaWiki\Title\Title;
 use Wikimedia\Rdbms\ILoadBalancer;
 
 /**
@@ -80,7 +82,7 @@ class TileTranslator extends SpecialPage {
     public static function updateTable($id, $displayName, $description, $language, $user, ILoadBalancer $dbLoadBalancer, $comment = '') {
         $dbw = $dbLoadBalancer->getConnection(DB_PRIMARY);
         if (empty($language)) return false;
-        
+
         $numExisting = $dbw->newSelectQueryBuilder()
         	->select('*')
         	->from('ext_tilesheet_languages')
@@ -148,7 +150,7 @@ class TileTranslator extends SpecialPage {
         	->where(array('entry_id' => $id, 'lang' => $language))
         	->fetchRowCount();
         if ($numExisting == 0) return false;
-        
+
         try {
         	$dbw->newDeleteQueryBuilder()
         		->deleteFrom('ext_tilesheet_languages')

--- a/special/WhatUsesThisTile.php
+++ b/special/WhatUsesThisTile.php
@@ -1,5 +1,7 @@
 <?php
 
+use MediaWiki\Html\FormOptions;
+use MediaWiki\Title\Title;
 use Wikimedia\Rdbms\ILoadBalancer;
 
 class WhatUsesThisTile extends SpecialPage {


### PR DESCRIPTION
The associated non-namespaced class aliases are no longer present, breaking the extension on MW >= 1.44. Raise the MW requirement to 1.40 accordingly.